### PR TITLE
Custom Repository Decorator 추가 및 설정

### DIFF
--- a/src/api/plan/plan.module.ts
+++ b/src/api/plan/plan.module.ts
@@ -1,15 +1,14 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { Plan } from '@/entity/plan.entity';
+import { TypeOrmExModule } from '@/common/typeOrmEx.module';
 
 import { PlanController } from './plan.controller';
 import { PlanRepository } from './plan.repository';
 import { PlanService } from './plan.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Plan])],
+  imports: [TypeOrmExModule.forFeature([PlanRepository])],
   controllers: [PlanController],
-  providers: [PlanService, PlanRepository],
+  providers: [PlanService],
 })
 export class PlanModule {}

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -1,14 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
+import { CustomRepository } from '@/common/customRepository.decorator';
 import { Plan } from '@/entity/plan.entity';
 
-@Injectable()
+@CustomRepository(Plan)
 export class PlanRepository extends Repository<Plan> {
-  constructor(dataSource: DataSource) {
-    super(Plan, dataSource.createEntityManager());
-  }
-
   async createPlan(planName: string) {
     return this.save(this.create({ planName }));
   }

--- a/src/api/user/user.module.ts
+++ b/src/api/user/user.module.ts
@@ -1,17 +1,15 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { PlanRepository } from '@/api/plan/plan.repository';
 import { UserRepository } from '@/api/user/user.repository';
-import { Plan } from '@/entity/plan.entity';
-import { User } from '@/entity/user.entity';
+import { TypeOrmExModule } from '@/common/typeOrmEx.module';
 
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Plan])],
+  imports: [TypeOrmExModule.forFeature([UserRepository, PlanRepository])],
   controllers: [UserController],
-  providers: [UserService, UserRepository, PlanRepository],
+  providers: [UserService],
 })
 export class UserModule {}

--- a/src/api/user/user.repository.ts
+++ b/src/api/user/user.repository.ts
@@ -1,14 +1,10 @@
-import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 
+import { CustomRepository } from '@/common/customRepository.decorator';
 import { User } from '@/entity/user.entity';
 
-@Injectable()
+@CustomRepository(User)
 export class UserRepository extends Repository<User> {
-  constructor(dataSource: DataSource) {
-    super(User, dataSource.createEntityManager());
-  }
-
   async createUser(username: string) {
     return this.save(this.create({ username }));
   }

--- a/src/common/customRepository.decorator.ts
+++ b/src/common/customRepository.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { PLANDAR_CUSTOM_REPSOITORY } from '@/utils/constants';
+
+export function CustomRepository<T>(
+  entity: new (...args: unknown[]) => T,
+): ClassDecorator {
+  return SetMetadata(PLANDAR_CUSTOM_REPSOITORY, entity);
+}

--- a/src/common/typeOrmEx.module.ts
+++ b/src/common/typeOrmEx.module.ts
@@ -1,0 +1,44 @@
+import { DynamicModule, Provider } from '@nestjs/common';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import type { DataSource, EntitySchema, ObjectLiteral } from 'typeorm';
+
+import { PLANDAR_CUSTOM_REPSOITORY } from '@/utils/constants';
+
+export class TypeOrmExModule {
+  public static forFeature<T extends new (...args: unknown[]) => any>(
+    repositories: T[],
+  ): DynamicModule {
+    const providers: Provider[] = [];
+
+    for (const Repository of repositories) {
+      const TargetEntity = Reflect.getMetadata(
+        PLANDAR_CUSTOM_REPSOITORY,
+        Repository,
+      ) as EntitySchema<ObjectLiteral>;
+
+      if (!TargetEntity) {
+        continue;
+      }
+
+      providers.push({
+        inject: [getDataSourceToken()],
+        provide: Repository,
+        useFactory: (dataSource: DataSource): typeof Repository => {
+          const baseRepository = dataSource.getRepository(TargetEntity);
+
+          return new Repository(
+            baseRepository.target,
+            baseRepository.manager,
+            baseRepository.queryRunner,
+          );
+        },
+      });
+    }
+
+    return {
+      exports: providers,
+      module: TypeOrmExModule,
+      providers,
+    };
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,1 @@
-export const PLANDAR_NAMESPACE = 'plandar';
-export const PLANDAR_ENTITY_MANAGER = 'plandarEntityManager';
+export const PLANDAR_CUSTOM_REPSOITORY = 'PLANDAR_CUSTOM_REPSOITORY';


### PR DESCRIPTION
* Closes #9

## ✨ **구현 기능 명세**

- Custom Repository Decorator
- Custom TypeORM Module

## 🎁 **주목할 점**

1. Metadata 설정하기 / [NestJS](https://docs.nestjs.com/fundamentals/execution-context#reflection-and-metadata) / [Typescript Library => reflect-metadata](https://www.npmjs.com/package/reflect-metadata)

요약하자면, NestJS에서 Class가 모듈에서 확실하게 동작하게 만들 수 있게 제공하는 Custom Metadata 설정 기능을 사용했다는 것
이 기능을 사용해 각 Repository에서 사용하고 있는 Entity Class를 알 수 있다.

```typescript
import { SetMetadata } from '@nestjs/common';

import { PLANDAR_CUSTOM_REPSOITORY } from '@/utils/constants';
// ...
    SetMetadata(PLANDAR_CUSTOM_REPSOITORY, entity);
// ...
```

2. Metadata 를 사용해 우리의 Custom Repository를 TypeORM Repository와 연동하기

TypeORM의 dataSource 객체에서 getRepository를 통해 Entity Class를 넣어주면 기본 기능인 Repository를 얻을 수 있다.
이를 통해 내부적으로 동작하는 target, manager, QueryRunner을 Custom Repository에 넣어줌으로써 기본 기능 Repository 사용과 함께 extends된 method를 함께 사용할 수 있다.

```typescript
    const baseRepository = dataSource.getRepository(TargetEntity);
    return new Repository(
        baseRepository.target,
        baseRepository.manager,
        baseRepository.queryRunner,
    );
```

3. 사용하기

2번과 같이 Repository 설정을 해주는 Module의 static method를 이용해서 imports에 넣게 되면 사용할 수 있다.
```typescript
@Module({
  imports: [TypeOrmExModule.forFeature([PlanRepository])],
  controllers: [PlanController],
  providers: [PlanService],
})
export class PlanModule {}
```

## 😭 어려웠던 점

이 기능은 NestJS의 Dynamic Module을 사용했다는 점! [Dynamic Modules](https://docs.nestjs.com/fundamentals/dynamic-modules#dynamic-modules)
간단한 설명으로는 모듈의 imports 속성에서 메서드가 실행될 때 return 되는 값들을 아래 속성들과 함께 추가할 수 있는 방법이다!
`useFactory`와 함께 Dynamic Modules 개념을 아는 것이 핵심이였는데, 좀 어려웠다