### PR TITLE
User Contoller 테스트 및 비즈니스 로직 생성

### DIFF
--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 import { UserService } from '@/api/user/user.service';
 import { User } from '@/decorators/user.decorator';
@@ -10,16 +16,18 @@ import { JwtAuthGuard } from '@/guard/jwt-auth.guard';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @ApiResponse({
-    status: 500,
+  @ApiInternalServerErrorResponse({
     description: '데이터 베이스에서 제대로 값을 읽어오지 못한 경우',
   })
-  @ApiResponse({ status: 400, description: '유저 정보가 존재하지 않을경우' })
+  @ApiUnauthorizedResponse({
+    description: 'access된 유저가 인증되지 않은 유저일 경우',
+  })
+  @ApiNotFoundResponse({ description: '유저 정보가 존재하지 않을경우' })
   @ApiResponse({ status: 200, type: UserEntity })
   @ApiOperation({ summary: '유저 정보 가져오기' })
   @UseGuards(JwtAuthGuard)
   @Get()
   getUser(@User() user: UserEntity) {
-    return this.userService.getUser(user.id);
+    return this.userService.getUser(user?.id);
   }
 }

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -1,12 +1,10 @@
-import { Controller, Get, Post, Query } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 import { UserService } from '@/api/user/user.service';
-import {
-  CreateUserQueryDto,
-  CreateUserRetDto,
-} from '@/dto/user/create-user.dto';
-import { User } from '@/entity/user.entity';
+import { User } from '@/decorators/user.decorator';
+import { User as UserEntity } from '@/entity/user.entity';
+import { JwtAuthGuard } from '@/guard/jwt-auth.guard';
 
 @Controller('user')
 export class UserController {
@@ -16,35 +14,12 @@ export class UserController {
     status: 500,
     description: '데이터 베이스에서 제대로 값을 읽어오지 못한 경우',
   })
-  @ApiResponse({
-    status: 200,
-    type: User,
-    isArray: true,
-  })
-  @ApiOperation({ summary: '모든 유저정보 데이터 가져오기' })
+  @ApiResponse({ status: 400, description: '유저 정보가 존재하지 않을경우' })
+  @ApiResponse({ status: 200, type: UserEntity })
+  @ApiOperation({ summary: '유저 정보 가져오기' })
+  @UseGuards(JwtAuthGuard)
   @Get()
-  async getUsers() {
-    return this.userService.getUsers();
-  }
-
-  @ApiResponse({
-    status: 500,
-    description: '트랜잭션 실패한 경우',
-  })
-  @ApiResponse({
-    status: 400,
-    description: '올바른 쿼리를 넣어주지 않은 경우',
-  })
-  @ApiResponse({
-    status: 200,
-    type: CreateUserRetDto,
-    isArray: true,
-  })
-  @ApiOperation({ summary: '3 * time 만큼의 새로운 유저 생성' })
-  @Post()
-  async createUser(@Query() { time, success }: CreateUserQueryDto) {
-    return time
-      ? this.userService.createUserWithTime(time, success)
-      : this.userService.createUser(success);
+  getUser(@User() user: UserEntity) {
+    return this.userService.getUser(user.id);
   }
 }

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -2,8 +2,8 @@ import { Controller, Get, UseGuards } from '@nestjs/common';
 import {
   ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
-  ApiResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 
@@ -23,7 +23,7 @@ export class UserController {
     description: 'access된 유저가 인증되지 않은 유저일 경우',
   })
   @ApiNotFoundResponse({ description: '유저 정보가 존재하지 않을경우' })
-  @ApiResponse({ status: 200, type: UserEntity })
+  @ApiOkResponse({ type: UserEntity })
   @ApiOperation({ summary: '유저 정보 가져오기' })
   @UseGuards(JwtAuthGuard)
   @Get()

--- a/src/api/user/user.service.ts
+++ b/src/api/user/user.service.ts
@@ -1,7 +1,7 @@
 import {
-  BadRequestException,
   Injectable,
-  InternalServerErrorException,
+  ConflictException,
+  NotFoundException,
 } from '@nestjs/common';
 
 import { UserRepository } from '@/api/user/user.repository';
@@ -16,7 +16,7 @@ export class UserService {
     const user = await this.userRepo.getUserById(id);
 
     if (!user) {
-      throw new BadRequestException('존재하지 않는 유저입니다.');
+      throw new NotFoundException('존재하지 않는 유저입니다.');
     }
 
     return user;
@@ -28,7 +28,7 @@ export class UserService {
     });
 
     if (user) {
-      throw new BadRequestException('이미 존재하는 유저입니다.');
+      throw new ConflictException('이미 존재하는 유저입니다.');
     }
 
     return this.userRepo.createUser(userInfo);

--- a/src/decorators/user.decorator.ts
+++ b/src/decorators/user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+
+    if (!request.user) throw new Error('유저 정보가 존재하지 않습니다.');
+
+    return request.user;
+  },
+);

--- a/src/guard/jwt-auth.guard.ts
+++ b/src/guard/jwt-auth.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(context: any) {
+    return true;
+  }
+  handleRequest(err, user, info) {
+    if (err || !user) {
+      return null;
+    }
+    return user;
+  }
+}

--- a/test/api/user/mock.ts
+++ b/test/api/user/mock.ts
@@ -5,8 +5,19 @@ const USER_STUB: User = {
   email: 'test@test.com',
   username: '테스트',
   profileImage: '이미지',
-  createdAt: new Date('2023-03-07 15:38:06.785155'),
-  updatedAt: new Date('2023-03-07 15:38:06.785155'),
+  createdAt: new Date(
+    '2023-03-07 15:38:06.785155',
+  ).toISOString() as unknown as Date,
+  updatedAt: new Date(
+    '2023-03-07 15:38:06.785155',
+  ).toISOString() as unknown as Date,
 };
 
-export { USER_STUB };
+const GET_USER_ERROR_STUB = {
+  error: 'Bad Request',
+  message: '존재하지 않는 유저입니다.',
+  statusCode: 400,
+  success: false,
+};
+
+export { USER_STUB, GET_USER_ERROR_STUB };

--- a/test/api/user/user.controller.spec.ts
+++ b/test/api/user/user.controller.spec.ts
@@ -1,24 +1,99 @@
-import type { INestApplication } from '@nestjs/common';
+import {
+  BadRequestException,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import * as testRequest from 'supertest';
 
 import { UserController } from '@/api/user/user.controller';
 import { UserService } from '@/api/user/user.service';
+import { HttpExceptionFilter } from '@/common/http-exception.filter';
+import { SuccessInterceptor } from '@/common/success.interceptor';
+import { JwtAuthGuard } from '@/guard/jwt-auth.guard';
 import createTestingModule from 'test/utils/createTestingModule';
 
+import { GET_USER_ERROR_STUB, USER_STUB } from './mock';
+
 describe('UserController', () => {
+  const mockUser = Object.assign({}, USER_STUB);
+  const mockJwtAuthGuard = {
+    canActivate: jest.fn(() => true),
+    handleRequest: jest.fn(() => ({ id: mockUser.id })),
+  };
+
   let app: INestApplication;
   let userService: UserService;
 
   beforeEach(async () => {
-    const moduleRef = await createTestingModule({
-      controllers: [UserController],
-    });
+    const moduleRef = await createTestingModule(
+      {
+        controllers: [UserController],
+      },
+      undefined,
+      (builder) => {
+        builder.overrideGuard(JwtAuthGuard).useValue(mockJwtAuthGuard);
+      },
+    );
 
-    userService = moduleRef.get<UserService>(UserService);
     app = moduleRef.createNestApplication();
+
+    app.useGlobalFilters(new HttpExceptionFilter());
+    app.useGlobalInterceptors(new SuccessInterceptor());
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
     await app.init();
+
+    userService = await app.resolve<UserService>(UserService);
   });
 
   it('Check defining Modules', () => {
     expect(userService).toBeDefined();
+  });
+
+  describe('GET /user', () => {
+    it('expect success response with user', async () => {
+      // given
+      const id = mockUser.id;
+      const user = { ...mockUser };
+      const result = {
+        success: true,
+        data: user,
+      };
+      const userServSpy = jest
+        .spyOn(userService, 'getUser')
+        .mockResolvedValue(user);
+
+      // when
+      const request = await testRequest(app.getHttpServer())
+        .get(`/user`)
+        .expect(200);
+
+      // then
+      expect(userServSpy).toHaveBeenCalledWith(id);
+      expect(request.body).toEqual(result);
+    });
+
+    it('expect failure response with user', async () => {
+      // given
+      const id = mockUser.id;
+      const userServSpy = jest
+        .spyOn(userService, 'getUser')
+        .mockRejectedValue(
+          new BadRequestException('존재하지 않는 유저입니다.'),
+        );
+
+      // when
+      const request = await testRequest(app.getHttpServer())
+        .get(`/user`)
+        .expect(400);
+
+      const result = {
+        ...GET_USER_ERROR_STUB,
+        timestamp: request.body.timestamp,
+      };
+
+      expect(userServSpy).toHaveBeenCalledWith(id);
+      expect(request.body).toEqual(result);
+    });
   });
 });

--- a/test/api/user/user.controller.spec.ts
+++ b/test/api/user/user.controller.spec.ts
@@ -1,6 +1,6 @@
 import {
-  BadRequestException,
   INestApplication,
+  NotFoundException,
   ValidationPipe,
 } from '@nestjs/common';
 import * as testRequest from 'supertest';
@@ -76,9 +76,7 @@ describe('UserController', () => {
       const id = mockUser.id;
       const userServSpy = jest
         .spyOn(userService, 'getUser')
-        .mockRejectedValue(
-          new BadRequestException('존재하지 않는 유저입니다.'),
-        );
+        .mockRejectedValue(new NotFoundException('존재하지 않는 유저입니다.'));
 
       // when
       const request = await testRequest(app.getHttpServer())

--- a/test/api/user/user.controller.spec.ts
+++ b/test/api/user/user.controller.spec.ts
@@ -10,16 +10,14 @@ import { UserService } from '@/api/user/user.service';
 import { HttpExceptionFilter } from '@/common/http-exception.filter';
 import { SuccessInterceptor } from '@/common/success.interceptor';
 import { JwtAuthGuard } from '@/guard/jwt-auth.guard';
+import { createMockJwtAuthGuard } from 'test/utils/createMockJwtAuthGuard';
 import createTestingModule from 'test/utils/createTestingModule';
 
 import { GET_USER_ERROR_STUB, USER_STUB } from './mock';
 
 describe('UserController', () => {
   const mockUser = Object.assign({}, USER_STUB);
-  const mockJwtAuthGuard = {
-    canActivate: jest.fn(() => true),
-    handleRequest: jest.fn(() => ({ id: mockUser.id })),
-  };
+  const mockJwtAuthGuard = createMockJwtAuthGuard(mockUser.id);
 
   let app: INestApplication;
   let userService: UserService;

--- a/test/api/user/user.service.spec.ts
+++ b/test/api/user/user.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 
 import { UserRepository } from '@/api/user/user.repository';
 import { UserService } from '@/api/user/user.service';
@@ -53,7 +53,8 @@ describe('UserService', () => {
         await userService.getUser(id);
       } catch (error) {
         // then
-        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.status).toEqual(404);
+        expect(error).toBeInstanceOf(NotFoundException);
       }
     });
   });
@@ -94,7 +95,8 @@ describe('UserService', () => {
         await userService.createUser(newUser);
       } catch (error) {
         // then
-        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.status).toEqual(409);
+        expect(error).toBeInstanceOf(ConflictException);
       }
     });
   });

--- a/test/utils/createMockJwtAuthGuard.ts
+++ b/test/utils/createMockJwtAuthGuard.ts
@@ -1,0 +1,9 @@
+import { ExecutionContext } from '@nestjs/common';
+
+export const createMockJwtAuthGuard = (id: number) => ({
+  canActivate: (context: ExecutionContext) => {
+    const request = context.switchToHttp().getRequest();
+    request.user = { id };
+    return true;
+  },
+});


### PR DESCRIPTION
* Closes #18
* Closes #19 

## ✨ **구현 기능 명세**
- user controller 관련 test 및 비즈니스 로직을 생성했습니다.
- user controller는 총 1개의 함수가 존재하며 내용은 다음과 같습니다.
  - `getUser`:  요청받은 user id에 따라 user를 반환합니다.

## 🎁 **주목할 점**

### `JwtAuthGuard`
- 현재 `user.controller.ts`에선 dummy `JwtAuthGuard`가 설정되어 있습니다. 본래 기능은 허용되지 않은 유저가 접근하는 것을 막는 용도의 decorator가 아닌 무조건 true를 내뱉는 decorator 입니다.
- 해당 부분은 추후 `@nestjs/passport` 라이브러리를 통해 추가적으로 구현해야 합니다.

```ts
// src/guard/jwt-auth.guard.ts
@Injectable()
export class JwtAuthGuard implements CanActivate {
  canActivate(context: any) {
    return true;
  }
  ...
}

// src/api/user/user.controller.ts
@Controller('user')
export class UserController {
  constructor(private readonly userService: UserService) {}
  ...
  @UseGuards(JwtAuthGuard)
  @Get()
  getUser() {
     ...
  }
}
```
### `User Decorator`
- nestjs에서 제공하는 `createParamDecorator`를 통해 Custom Decorator를 생성했습니다.
- 해당 함수의 기능은 후에 생성할 `JwtStrategy`를 통해 context.request에 등록될 user 객체를 가저와 반환하는 Decorator입니다.

```ts
// src/decrators/user.decorator.ts
export const User = createParamDecorator(
  (data: unknown, ctx: ExecutionContext) => {
    const request = ctx.switchToHttp().getRequest();

    if (!request.user) throw new Error('유저 정보가 존재하지 않습니다.');

    return request.user;
  },
);

// src/api/user/user.controller.ts
@Controller('user')
export class UserController {
  constructor(private readonly userService: UserService) {}
  ...
  @UseGuards(JwtAuthGuard)
  @Get()
  getUser(@User() user: UserEntity) {
    return this.userService.getUser(user.id);
  }
}
```

### 테스트 관련
- 위에서 생성한 `JwtAuthGuard`는 테스트에서 정상적으로 동작하지 않습니다.
- 때문에 해당 class를 mocking하여 테스트를 진행합니다.
- 특정 request 요청 완료시 실제 api 응답과 형식을 맞추기 위해 생성된 TestModule에 `ExceptionFilter`, `Interceptor`, `ValidationPipe`를 적용합니다.


```ts
// test/utils/createMockJwtAuthGuard.ts
export const createMockJwtAuthGuard = (id: number) => ({
  canActivate: (context: ExecutionContext) => {
    const request = context.switchToHttp().getRequest();
    request.user = { id };
    return true;
  },
});

// test/api/user/user.controller.spec.ts
describe('UserController', () => {
  const mockUser = Object.assign({}, USER_STUB);
  const mockJwtAuthGuard = createMockJwtAuthGuard(mockUser.id);

  let app: INestApplication;
  let userService: UserService;

  beforeEach(async () => {
    const moduleRef = await createTestingModule(
      {
        controllers: [UserController],
      },
      undefined,
      (builder) => {
        // mocking JwtAuthGuard
        builder.overrideGuard(JwtAuthGuard).useValue(mockJwtAuthGuard);
      },
    );

    app = moduleRef.createNestApplication();

    app.useGlobalFilters(new HttpExceptionFilter());
    app.useGlobalInterceptors(new SuccessInterceptor());
    app.useGlobalPipes(new ValidationPipe({ transform: true }));

    await app.init();

    userService = await app.resolve<UserService>(UserService);
  });
  ...
});

```

## 🌄 **스크린샷**
<img width="410" alt="image" src="https://user-images.githubusercontent.com/60173534/226871059-03e9f2ea-cc5e-4992-ba7b-1a5f22d029b3.png">
- 정상적으로 테스트가 실행됩니다.
