### PR TITLE
Category Controller 구현

### DIFF
--- a/src/api/category/category.controller.ts
+++ b/src/api/category/category.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+
+import { CategoryService } from '@/api/category/category.service';
+
+@Controller('category')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryService) {}
+}

--- a/src/api/category/category.controller.ts
+++ b/src/api/category/category.controller.ts
@@ -19,8 +19,11 @@ import {
 } from '@nestjs/swagger';
 
 import { CategoryService } from '@/api/category/category.service';
-import { CategoryCreateReqDto, CategoryUpdateReqDto } from '@/dto/category';
-import { CategoryResDto } from '@/dto/category/category-res.dto';
+import {
+  CategoryCreateReqDto,
+  CategoryUpdateReqDto,
+  CategoryResDto,
+} from '@/dto/category';
 
 const USER_ID = 1;
 

--- a/src/api/category/category.controller.ts
+++ b/src/api/category/category.controller.ts
@@ -1,8 +1,110 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
 
 import { CategoryService } from '@/api/category/category.service';
+import { CategoryCreateReqDto, CategoryUpdateReqDto } from '@/dto/category';
+import { CategoryResDto } from '@/dto/category/category-res.dto';
 
+const USER_ID = 1;
+
+@ApiTags('category')
 @Controller('category')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
+
+  @ApiOperation({
+    summary: '카테고리 조회',
+  })
+  @ApiOkResponse({
+    description: '카테고리 조회 성공',
+    type: CategoryResDto,
+    isArray: true,
+  })
+  @Get()
+  async readCategory() {
+    return this.categoryService.readCategory(USER_ID);
+  }
+
+  @ApiOperation({
+    summary: '카테고리 생성',
+  })
+  @ApiCreatedResponse({
+    description: '카테고리 생성 성공',
+    type: CategoryResDto,
+  })
+  @ApiConflictResponse({
+    description: '이미 카테고리가 존재함',
+  })
+  @Post()
+  async createCategory(
+    @Body() { name: categoryName, color }: CategoryCreateReqDto,
+  ) {
+    return this.categoryService.createCategory({
+      userId: USER_ID,
+      categoryName,
+      color,
+    });
+  }
+
+  @ApiOperation({
+    summary: '카테고리 수정',
+  })
+  @ApiOkResponse({
+    description: '카테고리 수정 성공',
+    type: CategoryResDto,
+  })
+  @ApiConflictResponse({
+    description:
+      '카테고리가 존재하지 않거나 동일한 이름으로 수정하려고 하는 경우',
+  })
+  @ApiUnprocessableEntityResponse({
+    description: 'Request Body에 name, color가 모두 없는 경우',
+  })
+  @Put(':categoryId')
+  async updateCategory(
+    @Param('categoryId', ParseIntPipe) categoryId: number,
+    @Body() { name: categoryName, color }: CategoryUpdateReqDto,
+  ) {
+    if (!(categoryName || color)) {
+      throw new UnprocessableEntityException();
+    }
+    return this.categoryService.updateCategory({
+      userId: USER_ID,
+      categoryId,
+      categoryName,
+      color,
+    });
+  }
+
+  @ApiOperation({
+    summary: '카테고리 삭제',
+  })
+  @ApiOkResponse({
+    description: '카테고리 삭제 성공',
+    type: CategoryResDto,
+  })
+  @ApiConflictResponse({
+    description: '카테고리가 존재하지 않는 경우',
+  })
+  @Delete(':categoryId')
+  async deleteCategory(@Param('categoryId', ParseIntPipe) categoryId: number) {
+    return this.categoryService.deleteCategory({ userId: USER_ID, categoryId });
+  }
 }

--- a/src/api/category/category.module.ts
+++ b/src/api/category/category.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { CategoryRepository } from '@/api/category/category.repository';
+import { TypeOrmExModule } from '@/common/typeOrmEx.module';
+
+import { CategoryController } from './category.controller';
+import { CategoryService } from './category.service';
+
+@Module({
+  imports: [TypeOrmExModule.forFeature([CategoryRepository])],
+  controllers: [CategoryController],
+  providers: [CategoryService],
+})
+export class CategoryModule {}

--- a/src/api/category/category.repository.ts
+++ b/src/api/category/category.repository.ts
@@ -1,0 +1,7 @@
+import { Repository } from 'typeorm';
+
+import { CustomRepository } from '@/common/customRepository.decorator';
+import { Category } from '@/entity/category.entity';
+
+@CustomRepository(Category)
+export class CategoryRepository extends Repository<Category> {}

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import { CategoryRepository } from '@/api/category/category.repository';
+
+@Injectable()
+export class CategoryService {
+  constructor(private readonly categoryRepo: CategoryRepository) {}
+
+  async readCategories(): Promise<any> {
+    return Promise.resolve();
+  }
+
+  async createCategory(): Promise<any> {
+    return Promise.resolve();
+  }
+
+  async updateCategory(): Promise<any> {
+    return Promise.resolve();
+  }
+
+  async deleteCategory(): Promise<any> {
+    return Promise.resolve();
+  }
+}

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -1,24 +1,41 @@
 import { Injectable } from '@nestjs/common';
 
 import { CategoryRepository } from '@/api/category/category.repository';
+import {
+  CreateCategoryArgs,
+  DeleteCategoryArgs,
+  UpdateCategoryArgs,
+} from '@/dto/category';
 
 @Injectable()
 export class CategoryService {
   constructor(private readonly categoryRepo: CategoryRepository) {}
 
-  async readCategories(): Promise<any> {
+  async readCategory(userId: number): Promise<any> {
     return Promise.resolve();
   }
 
-  async createCategory(): Promise<any> {
+  async createCategory({
+    userId,
+    categoryName,
+    color,
+  }: CreateCategoryArgs): Promise<any> {
     return Promise.resolve();
   }
 
-  async updateCategory(): Promise<any> {
+  async updateCategory({
+    userId,
+    categoryName,
+    categoryId,
+    color,
+  }: UpdateCategoryArgs): Promise<any> {
     return Promise.resolve();
   }
 
-  async deleteCategory(): Promise<any> {
+  async deleteCategory({
+    userId,
+    categoryId,
+  }: DeleteCategoryArgs): Promise<any> {
     return Promise.resolve();
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { UserModule } from '@/api/user/user.module';
 import { Plan } from '@/entity/plan.entity';
 import { User } from '@/entity/user.entity';
 
+import { CategoryModule } from './api/category/category.module';
 import { PlanModule } from './api/plan/plan.module';
 import { TagModule } from './api/tag/tag.module';
 import { Category } from './entity/category.entity';
@@ -45,6 +46,7 @@ import { Tag } from './entity/tag.entity';
     UserModule,
     PlanModule,
     TagModule,
+    CategoryModule,
   ],
 })
 export class AppModule {}

--- a/src/dto/category/args.ts
+++ b/src/dto/category/args.ts
@@ -1,0 +1,19 @@
+interface CreateCategoryArgs {
+  userId: number;
+  categoryName: string;
+  color?: number;
+}
+
+interface UpdateCategoryArgs {
+  userId: number;
+  categoryId: number;
+  categoryName?: string;
+  color?: number;
+}
+
+interface DeleteCategoryArgs {
+  userId: number;
+  categoryId: number;
+}
+
+export { CreateCategoryArgs, UpdateCategoryArgs, DeleteCategoryArgs };

--- a/src/dto/category/category-create-req.dto.ts
+++ b/src/dto/category/category-create-req.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional, PickType } from '@nestjs/swagger';
+import { IsNumber, IsOptional } from 'class-validator';
+
+import { Category } from '@/entity/category.entity';
+
+class CategoryCreateReqDto extends PickType(Category, ['name'] as const) {
+  @ApiPropertyOptional({
+    description: '카테고리 색상, 0x000000(0) ~ 0xffffff(16777215)',
+    example: 0x52d681,
+    minimum: 0x000000,
+    maximum: 0xffffff,
+    default: Buffer.from('0x52d681'),
+  })
+  @IsOptional()
+  @IsNumber()
+  color?: number;
+}
+
+export { CategoryCreateReqDto };

--- a/src/dto/category/category-res.dto.ts
+++ b/src/dto/category/category-res.dto.ts
@@ -1,0 +1,11 @@
+import { PickType } from '@nestjs/swagger';
+
+import { Category } from '@/entity/category.entity';
+
+class CategoryResDto extends PickType(Category, [
+  'name',
+  'id',
+  'color',
+] as const) {}
+
+export { CategoryResDto };

--- a/src/dto/category/category-update-req.dto.ts
+++ b/src/dto/category/category-update-req.dto.ts
@@ -1,0 +1,27 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+class CategoryUpdateReqDto {
+  @ApiPropertyOptional({
+    description: '카테고리 이름',
+    example: '운동',
+  })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: '카테고리 색상',
+    example: 0x52d681,
+    minimum: 0x000000,
+    maximum: 0xffffff,
+    default: Buffer.from('0x52d681'),
+  })
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => Buffer.from(value, 'hex'))
+  color?: number;
+}
+
+export { CategoryUpdateReqDto };

--- a/src/dto/category/index.ts
+++ b/src/dto/category/index.ts
@@ -1,0 +1,4 @@
+export * from './category-create-req.dto';
+export * from './category-update-req.dto';
+export * from './category-res.dto';
+export * from './args';

--- a/test/api/category/category.controller.spec.ts
+++ b/test/api/category/category.controller.spec.ts
@@ -1,0 +1,200 @@
+import { INestApplication } from '@nestjs/common';
+import * as testRequest from 'supertest';
+
+import { CategoryController } from '@/api/category/category.controller';
+import { CategoryService } from '@/api/category/category.service';
+import createTestingModule from 'test/utils/createTestingModule';
+
+import { STUB_CATEGORY } from './stub';
+
+describe('CategoryController', () => {
+  const stubCategory = Object.assign({}, STUB_CATEGORY);
+  let app: INestApplication;
+  let categoryService: CategoryService;
+
+  beforeEach(async () => {
+    const moduleRef = await createTestingModule({
+      controllers: [CategoryController],
+    });
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    categoryService = await app.resolve<CategoryService>(CategoryService);
+  });
+
+  it('Check defining Modules', () => {
+    expect(CategoryService).toBeDefined();
+  });
+
+  describe('GET /category', () => {
+    it('get all category', async () => {
+      // given
+      const userId = stubCategory[0].user.id;
+      const resBody = STUB_CATEGORY;
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'readCategories')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer()).get('/category');
+
+      // then
+      return request.expect(200).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith(userId);
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('POST /category', () => {
+    it('expect success response with created category (without color)', async () => {
+      // given
+      const userId = stubCategory[0].user.id;
+      const categoryName = stubCategory[0].name;
+      const categoryId = stubCategory[0].id;
+      const color = stubCategory[0].color;
+      const reqBody = { name: categoryName };
+      const resBody = { name: categoryName, id: categoryId, color };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'createCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .post('/category')
+        .send(reqBody);
+
+      // then
+      return request.expect(201).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({
+          categoryName,
+          userId,
+        });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('POST /category', () => {
+    it('expect success response with created category (with color)', async () => {
+      // given
+      const userId = stubCategory[0].user.id;
+      const categoryName = stubCategory[0].name;
+      const categoryId = stubCategory[0].id;
+      const color = stubCategory[0].color;
+      const reqBody = { name: categoryName, color };
+      const resBody = { name: categoryName, id: categoryId, color };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'createCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .post('/category')
+        .send(reqBody);
+
+      // then
+      return request.expect(201).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({
+          categoryName,
+          userId,
+        });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('PUT /category/:categoryId', () => {
+    it('expect success response with updated category (without color)', async () => {
+      // given
+      const newCategoryName = 'new category name';
+      const categoryId = stubCategory[0].id;
+      const userId = stubCategory[0].user.id;
+      const color = stubCategory[0].color;
+      const reqBody = { name: newCategoryName };
+      const resBody = {
+        name: newCategoryName,
+        id: categoryId,
+        color,
+      };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'updateCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .put(`/category/${categoryId}`)
+        .send(reqBody);
+
+      // then
+      return request.expect(200).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({
+          userId,
+          categoryId,
+          categoryName: newCategoryName,
+        });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('PUT /category/:categoryId', () => {
+    it('expect success response with updated category (with color)', async () => {
+      // given
+      const newCategoryName = 'new category name';
+      const newColor = 0x333333;
+      const categoryId = stubCategory[0].id;
+      const userId = stubCategory[0].user.id;
+      const reqBody = { name: newCategoryName, color: newColor };
+      const resBody = {
+        name: newCategoryName,
+        id: categoryId,
+        color: newColor,
+      };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'updateCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .put(`/category/${categoryId}`)
+        .send(reqBody);
+
+      // then
+      return request.expect(200).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({
+          userId,
+          categoryId,
+          color: newColor,
+          categoryName: newCategoryName,
+        });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('DELETE /category/:categoryId', () => {
+    it('expect success response with deleted category', async () => {
+      // given
+      const userId = stubCategory[0].user.id;
+      const categoryId = stubCategory[0].id;
+      const categoryName = stubCategory[0].name;
+      const color = stubCategory[0].color;
+      const resBody = { id: categoryId, name: categoryName, color };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'deleteCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer()).delete(
+        `/category/${categoryId}`,
+      );
+
+      // then
+      return request.expect(200).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({ userId, categoryId });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+});

--- a/test/api/category/category.controller.spec.ts
+++ b/test/api/category/category.controller.spec.ts
@@ -30,9 +30,13 @@ describe('CategoryController', () => {
     it('get all category', async () => {
       // given
       const userId = stubCategory[0].user.id;
-      const resBody = STUB_CATEGORY;
+      const resBody = STUB_CATEGORY.map((category) => ({
+        name: category.name,
+        id: category.id,
+        color: category.color,
+      }));
       const categoryServSpy = jest
-        .spyOn(categoryService, 'readCategories')
+        .spyOn(categoryService, 'readCategory')
         .mockResolvedValue(resBody);
 
       // when
@@ -98,6 +102,7 @@ describe('CategoryController', () => {
         expect(categoryServSpy).toHaveBeenCalledWith({
           categoryName,
           userId,
+          color,
         });
         expect(res.body).toEqual(resBody);
       });

--- a/test/api/category/category.controller.spec.ts
+++ b/test/api/category/category.controller.spec.ts
@@ -110,7 +110,22 @@ describe('CategoryController', () => {
   });
 
   describe('PUT /category/:categoryId', () => {
-    it('expect success response with updated category (without color)', async () => {
+    it('expect fail (without both categoryName & color)', async () => {
+      // given
+      const categoryId = stubCategory[0].id;
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .put(`/category/${categoryId}`)
+        .send({});
+
+      // then
+      return request.expect(422);
+    });
+  });
+
+  describe('PUT /category/:categoryId', () => {
+    it('expect success response with updated category (only categoryName)', async () => {
       // given
       const newCategoryName = 'new category name';
       const categoryId = stubCategory[0].id;
@@ -144,7 +159,41 @@ describe('CategoryController', () => {
   });
 
   describe('PUT /category/:categoryId', () => {
-    it('expect success response with updated category (with color)', async () => {
+    it('expect success response with updated category (only color)', async () => {
+      // given
+      const categoryName = stubCategory[0].name;
+      const categoryId = stubCategory[0].id;
+      const userId = stubCategory[0].user.id;
+      const color = stubCategory[1].color;
+      const reqBody = { color };
+      const resBody = {
+        name: categoryName,
+        id: categoryId,
+        color,
+      };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'updateCategory')
+        .mockResolvedValue(resBody);
+
+      // when
+      const request = testRequest(app.getHttpServer())
+        .put(`/category/${categoryId}`)
+        .send(reqBody);
+
+      // then
+      return request.expect(200).expect((res) => {
+        expect(categoryServSpy).toHaveBeenCalledWith({
+          userId,
+          categoryId,
+          color,
+        });
+        expect(res.body).toEqual(resBody);
+      });
+    });
+  });
+
+  describe('PUT /category/:categoryId', () => {
+    it('expect success response with updated category (without both categoryName & color)', async () => {
       // given
       const newCategoryName = 'new category name';
       const newColor = 0x333333;

--- a/test/api/category/stub.ts
+++ b/test/api/category/stub.ts
@@ -1,0 +1,36 @@
+import { Category } from '@/entity/category.entity';
+
+const STUB_CATEGORY: Category[] = [
+  {
+    id: 1,
+    name: 'category1',
+    color: 0x111111,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    user: {
+      id: 1,
+      username: 'test user',
+      email: 'test@test.com',
+      profileImage: 'test image',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  },
+  {
+    id: 2,
+    name: 'category2',
+    color: 0x222222,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    user: {
+      id: 1,
+      username: 'test user',
+      email: 'test@test.com',
+      profileImage: 'test image',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  },
+];
+
+export { STUB_CATEGORY };


### PR DESCRIPTION
* Closes #31 
* Closes #32 

## ✨ **구현 기능 명세**
Category Controller를 구현하였습니다.

## 🎁 **주목할 점**

### PUT의 body가 존재하지 않을 경우
카테고리 수정을 위한 `PUT` api를 호출하려면 body로 `{ name?: string; color?: number}` 를 넘겨주어야 합니다. (둘 중 하나 이상은 반드시 필요합니다.) 만약 둘 다 없다면 상태코드 422인 UnprocessableEntity 에러를 던집니다. 이 상태코드는 [RFC 문서](https://www.rfc-editor.org/rfc/rfc4918#section-11.2)에 의하면 422 상태코드는 문법상 오류는 없으나 content의 내용상 올바르지 않은 경우 발생하는 에러코드라고 합니다. 
`name`과 `color` 중 하나 이상이 필요한데 둘 모두 없는 경우는 422 상태코드에 어울린다고 생각하여 이 에러를 반환합니다.

## 😭 **어려웠던 점**
Tag api를 하느라 고생깨나 했기 때문에 크게 어렵지 않았습니다.

## 🌄 **스크린샷**

### Swagger
![image](https://user-images.githubusercontent.com/32933980/227532204-919327dd-82be-42fa-84fc-6f054a1bd1a5.png)

### Test
![image](https://user-images.githubusercontent.com/32933980/227532126-e521e6fd-150a-44c7-b9a7-1ba541f60124.png)
