### PR TITLE
이미 존재하는 Tag를 생성하려는 경우 로직 변경

### DIFF
--- a/src/api/tag/tag.service.ts
+++ b/src/api/tag/tag.service.ts
@@ -15,9 +15,9 @@ export class TagService {
   async createTag(createTagArgs: CreateTagArgs): Promise<TagResDto> {
     const tag = await this.tagRepo.findTagByName(createTagArgs);
     if (tag) {
-      throw new ConflictException('Tag already exists');
+      return tag;
     }
-    return this.tagRepo.createTag(createTagArgs);
+    return await this.tagRepo.createTag(createTagArgs);
   }
 
   async updateTag(updateTagArgs: UpdateTagArgs): Promise<TagResDto> {

--- a/test/api/tag/tag.service.spec.ts
+++ b/test/api/tag/tag.service.spec.ts
@@ -25,26 +25,25 @@ describe('TagService', () => {
     expect(tagService).toBeDefined();
   });
 
-  describe('fail create tag', () => {
-    it('request create tag already existed', async () => {
+  describe('success create tag', () => {
+    it('request already existed tag', async () => {
       // given
       const tagName = stubTag.name;
       const userId = stubTag.user.id;
-      const alreadyExistTag = { name: stubTag.name, id: stubTag.id };
       const params = { userId, tagName };
-      jest.spyOn(tagRepo, 'findTagByName').mockResolvedValue(alreadyExistTag);
+      const shouldBe = { name: stubTag.name, id: stubTag.id };
 
-      try {
-        // when
-        await tagService.createTag(params);
-      } catch (e) {
-        // then
-        expect(e).toBeInstanceOf(ConflictException);
-      }
+      const tagRepoFindByName = jest
+        .spyOn(tagRepo, 'findTagByName')
+        .mockResolvedValue(shouldBe);
+
+      // when
+      const result = await tagService.createTag(params);
+
+      // then
+      expect(tagRepoFindByName).toHaveBeenCalledWith(params);
+      expect(result).toEqual(shouldBe);
     });
-  });
-
-  describe('success create tag', () => {
     it("should return created tag's name and id", async () => {
       // given
       const tagName = stubTag.name;


### PR DESCRIPTION
* Closes #52 

## ✨ **구현 기능 명세**

- [x] createTag 로직 수정
    - [x] 태그가 존재하지 않을 경우 Tag 생성하여 반환
    - [x] 태그가 존재할 경우 반환

## 🌄 **스크린샷**

![image](https://user-images.githubusercontent.com/32933980/228778718-76b46d6a-30cf-440f-b39e-20efb6ced670.png)
