### PR TITLE
동일한 이름, 색상으로 카테고리 변경시 exception

### DIFF
--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -60,7 +60,11 @@ export class CategoryService {
       throw new ConflictException('Category does not exist');
     } else if (categoryByName) {
       throw new ConflictException('Category already exists');
-    } else if (
+    }
+
+    updateCategoryArgs.categoryName ??= category.name;
+    updateCategoryArgs.color ??= category.color;
+    if (
       category.name === updateCategoryArgs.categoryName &&
       category.color === updateCategoryArgs.color
     ) {
@@ -68,9 +72,6 @@ export class CategoryService {
         'Please change category to not same name or color',
       );
     }
-
-    updateCategoryArgs.categoryName ??= category.name;
-    updateCategoryArgs.color ??= category.color;
 
     return mapToHexColor(
       await this.categoryRepo.updateCategory(updateCategoryArgs),


### PR DESCRIPTION
## ✨ **구현 기능 명세**
동일한 이름, 색상으로 카테고리 변경시 exception이 발생하도록 구현하였으나 코드를 수정하면서 잘못된 로직으로 수정하였습니다. 이를 다시 올바르게 바로잡습니다.

## 🎁 **주목할 점**

```ts
    // 수정 후 위치
    updateCategoryArgs.categoryName ??= category.name;
    updateCategoryArgs.color ??= category.color;

    // 동일한 이름과 색상으로 업데이트하려고 할 때 에러 발생시키는 로직
    if (
      category.name === updateCategoryArgs.categoryName &&
      category.color === updateCategoryArgs.color
    ) {
      throw new ConflictException(
        'Please change category to not same name or color',
      );
    }

    // 수정 전 위치
    updateCategoryArgs.categoryName ??= category.name;
    updateCategoryArgs.color ??= category.color;
```
` category.name === updateCategoryArgs.categoryName && category.color === updateCategoryArgs.color`을 통해 같은 이름과 색상으로 업데이트 하는지 판단합니다. 이를 위해서 `updateCategoryArgs.categoryName ??= category.name; updateCategoryArgs.color ??= category.color;` 을 해당 로직 위로 옮겼습니다.

## 🌄 **스크린샷**

![image](https://user-images.githubusercontent.com/32933980/228783474-a7935554-e755-4d1d-9f7c-073e52fbb2d9.png)
