### PR TITLE
일정을 조작할 수 있는 API 작성

### DIFF
--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -3,13 +3,16 @@ import {
   Body,
   Controller,
   Get,
+  Param,
+  ParseIntPipe,
   Post,
+  Put,
   Query,
 } from '@nestjs/common';
 
 import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
-import { PlanCreateReqDto } from '@/dto/plan';
+import { PlanCreateReqDto, PlanUpdateReqDto } from '@/dto/plan';
 import { UserEntity } from '@/entities';
 
 import { PlanService } from './plan.service';
@@ -40,6 +43,24 @@ export class PlanController {
   ) {
     return this.planService.createPlan({
       ...createPlanReqDto,
+      userId: user.id,
+    });
+  }
+
+  @Put('/:planId')
+  async updatePlan(
+    @Param('planId', ParseIntPipe) planId: number,
+    @Body() updatePlanReqDto: PlanUpdateReqDto,
+    @User() user: UserEntity,
+  ) {
+    if (Object.keys(updatePlanReqDto).length === 0) {
+      throw new BadRequestException(
+        '일정을 수정하려면 적어도 유효한 값이 하나라도 있어야 합니다.',
+      );
+    }
+    return this.planService.updatePlan({
+      ...updatePlanReqDto,
+      planId,
       userId: user.id,
     });
   }

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   ParseIntPipe,
@@ -63,5 +64,13 @@ export class PlanController {
       planId,
       userId: user.id,
     });
+  }
+
+  @Delete('/:planId')
+  async deletePlan(
+    @Param('planId', ParseIntPipe) planId: number,
+    @User() user: UserEntity,
+  ) {
+    return this.planService.deletePlan({ planId, userId: user.id });
   }
 }

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -24,8 +24,8 @@ export class PlanController {
 
   @Get('/')
   async getPlans(
-    @Query('timeMin', new ParseDatePipe()) timeMin: Date,
-    @Query('timeMax', new ParseDatePipe()) timeMax: Date,
+    @Query('timemin', ParseDatePipe) timeMin: Date,
+    @Query('timemax', ParseDatePipe) timeMax: Date,
     @User() user: UserEntity,
   ) {
     if (timeMin > timeMax) {

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -1,8 +1,27 @@
-import { Controller } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+
+import { User } from '@/common/decorators/user.decorator';
+import { ParseDatePipe } from '@/common/pipes';
+import { UserEntity } from '@/entities';
 
 import { PlanService } from './plan.service';
 
 @Controller('plan')
 export class PlanController {
   constructor(private readonly planService: PlanService) {}
+
+  @Get('/')
+  async getPlans(
+    @Query('timeMin', new ParseDatePipe()) timeMin: Date,
+    @Query('timeMax', new ParseDatePipe()) timeMax: Date,
+    @User() user: UserEntity,
+  ) {
+    if (timeMin > timeMax) {
+      throw new BadRequestException(
+        '일정을 요구하는 시간 순서가 올바르지 않습니다.',
+      );
+    }
+
+    return this.planService.getPlans({ timeMin, timeMax, userId: user.id });
+  }
 }

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -1,7 +1,15 @@
-import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+} from '@nestjs/common';
 
 import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
+import { PlanCreateReqDto } from '@/dto/plan';
 import { UserEntity } from '@/entities';
 
 import { PlanService } from './plan.service';
@@ -23,5 +31,16 @@ export class PlanController {
     }
 
     return this.planService.getPlans({ timeMin, timeMax, userId: user.id });
+  }
+
+  @Post('/')
+  async createPlan(
+    @Body() createPlanReqDto: PlanCreateReqDto,
+    @User() user: UserEntity,
+  ) {
+    return this.planService.createPlan({
+      ...createPlanReqDto,
+      userId: user.id,
+    });
   }
 }

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { PlanResDto } from '@/dto/plan';
-import { IGetPlansArgs } from '@/types/args/plan';
+import { ICreatePlanArgs, IGetPlansArgs } from '@/types/args';
 
 import { PlanRepository } from './plan.repository';
 
@@ -13,7 +13,7 @@ export class PlanService {
     return [];
   }
 
-  async createPlan(data): Promise<PlanResDto> {
+  async createPlan(data: ICreatePlanArgs): Promise<PlanResDto> {
     return {} as PlanResDto;
   }
 

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
-import { PlanEntity } from '@/entities';
+import { PlanResDto } from '@/dto/plan';
+import { IGetPlansArgs } from '@/types/args/plan';
 
 import { PlanRepository } from './plan.repository';
 
@@ -8,19 +9,19 @@ import { PlanRepository } from './plan.repository';
 export class PlanService {
   constructor(private readonly planRepository: PlanRepository) {}
 
-  async getPlans(data): Promise<PlanEntity[]> {
+  async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
     return [];
   }
 
-  async createPlan(data): Promise<PlanEntity> {
-    return {} as PlanEntity;
+  async createPlan(data): Promise<PlanResDto> {
+    return {} as PlanResDto;
   }
 
-  async updatePlan(data): Promise<PlanEntity> {
-    return {} as PlanEntity;
+  async updatePlan(data): Promise<PlanResDto> {
+    return {} as PlanResDto;
   }
 
-  async deletePlan(data): Promise<PlanEntity> {
-    return {} as PlanEntity;
+  async deletePlan(data): Promise<PlanResDto> {
+    return {} as PlanResDto;
   }
 }

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -12,7 +12,7 @@ import { PlanRepository } from './plan.repository';
 
 @Injectable()
 export class PlanService {
-  constructor(private readonly planRepository: PlanRepository) {}
+  constructor(private readonly planRepo: PlanRepository) {}
 
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
     return [];

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 
 import { PlanResDto } from '@/dto/plan';
-import { ICreatePlanArgs, IGetPlansArgs } from '@/types/args';
+import {
+  ICreatePlanArgs,
+  IGetPlansArgs,
+  IUpdatePlanWithTagsArgs,
+} from '@/types/args';
 
 import { PlanRepository } from './plan.repository';
 
@@ -17,7 +21,7 @@ export class PlanService {
     return {} as PlanResDto;
   }
 
-  async updatePlan(data): Promise<PlanResDto> {
+  async updatePlan(data: IUpdatePlanWithTagsArgs): Promise<PlanResDto> {
     return {} as PlanResDto;
   }
 

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,8 +1,26 @@
 import { Injectable } from '@nestjs/common';
 
+import { PlanEntity } from '@/entities';
+
 import { PlanRepository } from './plan.repository';
 
 @Injectable()
 export class PlanService {
-  constructor(private readonly planRepo: PlanRepository) {}
+  constructor(private readonly planRepository: PlanRepository) {}
+
+  async getPlans(data): Promise<PlanEntity[]> {
+    return [];
+  }
+
+  async createPlan(data): Promise<PlanEntity> {
+    return {} as PlanEntity;
+  }
+
+  async updatePlan(data): Promise<PlanEntity> {
+    return {} as PlanEntity;
+  }
+
+  async deletePlan(data): Promise<PlanEntity> {
+    return {} as PlanEntity;
+  }
 }

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { PlanResDto } from '@/dto/plan';
 import {
   ICreatePlanArgs,
+  IDeletePlanArgs,
   IGetPlansArgs,
   IUpdatePlanWithTagsArgs,
 } from '@/types/args';
@@ -25,7 +26,7 @@ export class PlanService {
     return {} as PlanResDto;
   }
 
-  async deletePlan(data): Promise<PlanResDto> {
+  async deletePlan(data: IDeletePlanArgs): Promise<PlanResDto> {
     return {} as PlanResDto;
   }
 }

--- a/src/dto/plan/index.ts
+++ b/src/dto/plan/index.ts
@@ -1,2 +1,3 @@
 export * from './plan-create-req.dto';
 export * from './plan-res.dto';
+export * from './plan-update-req.dto';

--- a/src/dto/plan/index.ts
+++ b/src/dto/plan/index.ts
@@ -1,0 +1,2 @@
+export * from './plan-create-req.dto';
+export * from './plan-res.dto';

--- a/src/dto/plan/plan-create-req.dto.ts
+++ b/src/dto/plan/plan-create-req.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
+import { ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
   ArrayMaxSize,
   IsArray,
@@ -26,21 +26,23 @@ class PlanCreateReqDto extends PickType(PlanEntity, [
   @IsHexColor()
   color?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '일정이 속해있는 카테고리 아이디',
-    example: 100,
+    example: 1,
   })
+  @IsOptional()
   @IsNumber()
-  categoryId!: number;
+  categoryId?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '일정이 속해있는 카테고리 아이디',
-    example: 100,
+    example: ['태그1', '태그2'],
   })
+  @IsOptional()
   @IsArray()
   @ArrayMaxSize(5)
   @IsString({ each: true })
-  tags!: string[];
+  tags?: string[];
 }
 
 export { PlanCreateReqDto };

--- a/src/dto/plan/plan-create-req.dto.ts
+++ b/src/dto/plan/plan-create-req.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+import { PlanEntity } from '@/entities';
+
+class PlanCreateReqDto extends PickType(PlanEntity, [
+  'title',
+  'description',
+  'isAllDay',
+  'type',
+  'startTime',
+  'endTime',
+] as const) {
+  @ApiPropertyOptional({
+    description: '일정 색상, 0x000000(0) ~ 0xffffff(16777215)',
+    example: 0x52d681,
+    minimum: 0x000000,
+    maximum: 0xffffff,
+    default: Buffer.from('0x52d681'),
+  })
+  @IsOptional()
+  @IsString()
+  color?: string;
+
+  @ApiProperty({
+    description: '일정이 속해있는 카테고리 아이디',
+    example: 100,
+  })
+  @IsNumber()
+  categoryId!: number;
+
+  @ApiProperty({
+    description: '일정이 속해있는 카테고리 아이디',
+    example: 100,
+  })
+  @IsArray()
+  @ArrayMaxSize(5)
+  @IsString({ each: true })
+  tags!: string[];
+}
+
+export { PlanCreateReqDto };

--- a/src/dto/plan/plan-create-req.dto.ts
+++ b/src/dto/plan/plan-create-req.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
   ArrayMaxSize,
   IsArray,
+  IsHexColor,
   IsNumber,
   IsOptional,
   IsString,
@@ -18,14 +19,11 @@ class PlanCreateReqDto extends PickType(PlanEntity, [
   'endTime',
 ] as const) {
   @ApiPropertyOptional({
-    description: '일정 색상, 0x000000(0) ~ 0xffffff(16777215)',
-    example: 0x52d681,
-    minimum: 0x000000,
-    maximum: 0xffffff,
-    default: Buffer.from('0x52d681'),
+    description: '일정 색상, #000000 ~ #ffffff',
+    example: '#52d681',
   })
   @IsOptional()
-  @IsString()
+  @IsHexColor()
   color?: string;
 
   @ApiProperty({

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ArrayMaxSize, IsArray, IsNumber } from 'class-validator';
+
+import { TagResDto } from '@/dto/tag';
+import { PlanEntity } from '@/entities';
+
+class PlanResDto extends OmitType(PlanEntity, [
+  'createdAt',
+  'updatedAt',
+  'user',
+  'tags',
+  'category',
+] as const) {
+  @ApiProperty({
+    description: '일정이 속해있는 카테고리 아이디',
+  })
+  @IsNumber()
+  categoryId: number;
+
+  @ApiProperty({
+    description: '일정이 가지고 있는 태그 객체',
+  })
+  @IsArray()
+  @ArrayMaxSize(5)
+  tags?: TagResDto[];
+}
+
+export { PlanResDto };

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, OmitType } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { ArrayMaxSize, IsArray, IsNumber } from 'class-validator';
 
 import { TagResDto } from '@/dto/tag';
@@ -10,12 +10,13 @@ class PlanResDto extends OmitType(PlanEntity, [
   'user',
   'tags',
   'category',
+  'categoryId',
 ] as const) {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '일정이 속해있는 카테고리 아이디',
   })
   @IsNumber()
-  categoryId: number;
+  categoryId?: number;
 
   @ApiProperty({
     description: '일정이 가지고 있는 태그 객체',

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { ArrayMaxSize, IsArray, IsNumber } from 'class-validator';
 
 import { TagResDto } from '@/dto/tag';
@@ -18,7 +18,7 @@ class PlanResDto extends OmitType(PlanEntity, [
   @IsNumber()
   categoryId?: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '일정이 가지고 있는 태그 객체',
   })
   @IsArray()

--- a/src/dto/plan/plan-update-req.dto.ts
+++ b/src/dto/plan/plan-update-req.dto.ts
@@ -10,7 +10,10 @@ import {
   IsHexColor,
 } from 'class-validator';
 
-import { IsDateType } from '@/common/decorators/date-type.decorator';
+import {
+  IsDateType,
+  TransformDate,
+} from '@/common/decorators/date-type.decorator';
 import { PLAN_TYPE } from '@/entities';
 
 class PlanUpdateReqDto {
@@ -60,6 +63,7 @@ class PlanUpdateReqDto {
   })
   @IsOptional()
   @IsDateType()
+  @TransformDate()
   startTime?: Date;
 
   @ApiPropertyOptional({
@@ -68,11 +72,12 @@ class PlanUpdateReqDto {
   })
   @IsOptional()
   @IsDateType()
+  @TransformDate()
   endTime?: Date | null;
 
   @ApiPropertyOptional({
     description: '일정이 속해있는 카테고리 아이디',
-    example: 100,
+    example: 1,
   })
   @IsOptional()
   @IsNumber()

--- a/src/dto/plan/plan-update-req.dto.ts
+++ b/src/dto/plan/plan-update-req.dto.ts
@@ -1,0 +1,91 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsEnum,
+} from 'class-validator';
+
+import { IsDateType } from '@/common/decorators/date-type.decorator';
+import { PLAN_TYPE } from '@/entities';
+
+class PlanUpdateReqDto {
+  @ApiPropertyOptional({
+    description: '일정 제목',
+    example: '내일 목표',
+  })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiPropertyOptional({
+    description: '일정에 대해 유저가 써놓은 설명',
+    example: '이 일정은 지켜지지 않아도 된다.',
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: '일정이 나타내는 색상',
+    example: 123456,
+  })
+  @IsOptional()
+  @IsString()
+  color?: string;
+
+  @ApiPropertyOptional({
+    description: '일정이 종일에 해당하는지에 대한 여부',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isAllDay?: boolean;
+
+  @ApiPropertyOptional({
+    description: '일정이 속하는 타입, 일정 / 할 일 / 알람',
+    example: PLAN_TYPE.EVENT,
+  })
+  @IsOptional()
+  @IsEnum(PLAN_TYPE)
+  type?: PLAN_TYPE;
+
+  @ApiPropertyOptional({
+    description: '일정이 시작하는 시간',
+    example: new Date('2023-03-07 15:38:06.785155'),
+  })
+  @IsOptional()
+  @IsDateType()
+  startTime?: Date;
+
+  @ApiPropertyOptional({
+    description: '일정의 마지막 시간',
+    example: null,
+  })
+  @IsOptional()
+  @IsDateType()
+  endTime?: Date | null;
+
+  @ApiPropertyOptional({
+    description: '일정이 속해있는 카테고리 아이디',
+    example: 100,
+  })
+  @IsOptional()
+  @IsNumber()
+  categoryId?: number;
+
+  @ApiPropertyOptional({
+    description: '일정이 속해있는 태그의 묶음',
+    example: ['태그1', '태그2'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @IsString({ each: true })
+  tags?: string[];
+}
+
+export { PlanUpdateReqDto };

--- a/src/dto/plan/plan-update-req.dto.ts
+++ b/src/dto/plan/plan-update-req.dto.ts
@@ -7,6 +7,7 @@ import {
   IsOptional,
   IsString,
   IsEnum,
+  IsHexColor,
 } from 'class-validator';
 
 import { IsDateType } from '@/common/decorators/date-type.decorator';
@@ -31,10 +32,10 @@ class PlanUpdateReqDto {
 
   @ApiPropertyOptional({
     description: '일정이 나타내는 색상',
-    example: 123456,
+    example: '#52d681',
   })
+  @IsHexColor()
   @IsOptional()
-  @IsString()
   color?: string;
 
   @ApiPropertyOptional({

--- a/src/entities/plan.entity.ts
+++ b/src/entities/plan.entity.ts
@@ -7,6 +7,7 @@ import {
   IsString,
   MaxLength,
   IsNumber,
+  IsHexColor,
 } from 'class-validator';
 import {
   Column,
@@ -52,7 +53,7 @@ export class PlanEntity extends DefaultEntity {
     default: '52d681',
   })
   @IsNotEmpty()
-  @IsString()
+  @IsHexColor()
   color!: string;
 
   @ApiProperty()

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     abortOnError: true,
   });
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalInterceptors(new SuccessInterceptor());
   app.setGlobalPrefix('api');

--- a/src/types/args/index.ts
+++ b/src/types/args/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './category';
 export * from './tag';
+export * from './plan';

--- a/src/types/args/plan.ts
+++ b/src/types/args/plan.ts
@@ -19,9 +19,15 @@ interface IUpdatePlanWithTagsArgs extends PlanUpdateReqDto {
   planId: number;
 }
 
+interface IDeletePlanArgs {
+  userId: number;
+  planId: number;
+}
+
 export {
   IGetPlansArgs,
   ICreatePlanArgs,
   IUpdatePlanArgs,
   IUpdatePlanWithTagsArgs,
+  IDeletePlanArgs,
 };

--- a/src/types/args/plan.ts
+++ b/src/types/args/plan.ts
@@ -1,0 +1,7 @@
+interface IGetPlansArgs {
+  userId: number;
+  timeMin: Date;
+  timeMax: Date;
+}
+
+export { IGetPlansArgs };

--- a/src/types/args/plan.ts
+++ b/src/types/args/plan.ts
@@ -1,4 +1,4 @@
-import { PlanCreateReqDto } from '@/dto/plan';
+import { PlanCreateReqDto, PlanUpdateReqDto } from '@/dto/plan';
 
 interface IGetPlansArgs {
   userId: number;
@@ -10,4 +10,18 @@ interface ICreatePlanArgs extends PlanCreateReqDto {
   userId: number;
 }
 
-export { IGetPlansArgs, ICreatePlanArgs };
+interface IUpdatePlanArgs extends Omit<PlanUpdateReqDto, 'tags'> {
+  id: number;
+}
+
+interface IUpdatePlanWithTagsArgs extends PlanUpdateReqDto {
+  userId: number;
+  planId: number;
+}
+
+export {
+  IGetPlansArgs,
+  ICreatePlanArgs,
+  IUpdatePlanArgs,
+  IUpdatePlanWithTagsArgs,
+};

--- a/src/types/args/plan.ts
+++ b/src/types/args/plan.ts
@@ -1,7 +1,13 @@
+import { PlanCreateReqDto } from '@/dto/plan';
+
 interface IGetPlansArgs {
   userId: number;
   timeMin: Date;
   timeMax: Date;
 }
 
-export { IGetPlansArgs };
+interface ICreatePlanArgs extends PlanCreateReqDto {
+  userId: number;
+}
+
+export { IGetPlansArgs, ICreatePlanArgs };

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -243,4 +243,27 @@ describe('PlanController', () => {
       });
     });
   });
+
+  describe('Delete /plan/:planId', () => {
+    it('expect success response with deleting a plan', async () => {
+      const planRes = { ...PLAN_STUB };
+      const planServSpy = jest
+        .spyOn(planService, 'deletePlan')
+        .mockResolvedValue(planRes);
+      const result = {
+        success: true,
+        data: planRes,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .delete(`/plan/${PLAN_STUB.id}`)
+        .expect(200);
+
+      expect(planServSpy).toHaveBeenCalledWith({
+        planId: PLAN_STUB.id,
+        userId: USER_STUB.id,
+      });
+      expect(request.body).toEqual(result);
+    });
+  });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -1,8 +1,14 @@
-import type { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as testRequest from 'supertest';
 
 import { PlanController } from '@/api/plan/plan.controller';
 import { PlanService } from '@/api/plan/plan.service';
+import { HttpExceptionFilter } from '@/common/filters';
+import { SuccessInterceptor } from '@/common/interceptors';
 import createTestingModule from 'test/utils/create-testing-module';
+
+import { PLAN_STUB, PLAN_TIME_MAX_STUB, PLAN_TIME_MIN_STUB } from './stub';
+import { USER_STUB } from '../user/stub';
 
 describe('PlanController', () => {
   let app: INestApplication;
@@ -14,11 +20,45 @@ describe('PlanController', () => {
     });
 
     app = moduleRef.createNestApplication();
+
+    app.useGlobalFilters(new HttpExceptionFilter());
+    app.useGlobalInterceptors(new SuccessInterceptor());
+    app.useGlobalPipes(
+      new ValidationPipe({ transform: true, whitelist: true }),
+    );
+
     await app.init();
     planService = await app.resolve<PlanService>(PlanService);
   });
 
   it('Check defining Modules', () => {
     expect(planService).toBeDefined();
+  });
+
+  describe('GET /plan', () => {
+    it('expect success response - plans (Query with between time)', async () => {
+      const timeMin = PLAN_TIME_MIN_STUB;
+      const timeMax = PLAN_TIME_MAX_STUB;
+      const plans = [{ ...PLAN_STUB }];
+      const planServSpy = jest
+        .spyOn(planService, 'getPlans')
+        .mockResolvedValue(plans);
+      const result = {
+        success: true,
+        data: plans,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .get(`/plan`)
+        .query({ timeMin, timeMax })
+        .expect(200);
+
+      expect(planServSpy).toHaveBeenCalledWith({
+        timeMin,
+        timeMax,
+        userId: USER_STUB.id,
+      });
+      expect(request.body).toEqual(result);
+    });
   });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -154,5 +154,34 @@ describe('PlanController', () => {
       });
       expect(request.body).toEqual(result);
     });
+
+    it('expect failure response with invalid body', async () => {
+      const invalidPlan = {};
+      const planServSpy = jest
+        .spyOn(planService, 'createPlan')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Service의 createPlan이 실행되어선 안됩니다.',
+          ),
+        );
+      const result = {
+        error: 'Bad Request',
+        statusCode: 400,
+        success: false,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .post(`/plan`)
+        .send(invalidPlan)
+        .expect(400);
+
+      const { message, ...body } = request.body;
+      expect(planServSpy).toHaveBeenCalledTimes(0);
+      expect(body).toEqual({
+        ...result,
+        timestamp: request.body.timestamp,
+      });
+      expect(message).toBeInstanceOf(Array);
+    });
   });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -1,4 +1,8 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  INestApplication,
+  InternalServerErrorException,
+  ValidationPipe,
+} from '@nestjs/common';
 import * as testRequest from 'supertest';
 
 import { PlanController } from '@/api/plan/plan.controller';
@@ -59,6 +63,35 @@ describe('PlanController', () => {
         userId: USER_STUB.id,
       });
       expect(request.body).toEqual(result);
+    });
+
+    it('expect failure response with invalid time query (timeMin > timeMax)', async () => {
+      const timeMin = PLAN_TIME_MIN_STUB;
+      const timeMax = PLAN_TIME_MAX_STUB;
+      const planServSpy = jest
+        .spyOn(planService, 'getPlans')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Service의 getPlans가 실행되어선 안됩니다.',
+          ),
+        );
+      const result = {
+        error: 'Bad Request',
+        statusCode: 400,
+        success: false,
+        message: '일정을 요구하는 시간 순서가 올바르지 않습니다.',
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .get(`/plan`)
+        .query({ timeMin: timeMax, timeMax: timeMin })
+        .expect(400);
+
+      expect(planServSpy).toHaveBeenCalledTimes(0);
+      expect(request.body).toEqual({
+        ...result,
+        timestamp: request.body.timestamp,
+      });
     });
   });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -10,6 +10,7 @@ import { PlanService } from '@/api/plan/plan.service';
 import { HttpExceptionFilter } from '@/common/filters';
 import { SuccessInterceptor } from '@/common/interceptors';
 import createTestingModule from 'test/utils/create-testing-module';
+import { omitKey } from 'test/utils/omit-key';
 
 import { PLAN_STUB, PLAN_TIME_MAX_STUB, PLAN_TIME_MIN_STUB } from './stub';
 import { USER_STUB } from '../user/stub';
@@ -85,6 +86,33 @@ describe('PlanController', () => {
       const request = await testRequest(app.getHttpServer())
         .get(`/plan`)
         .query({ timeMin: timeMax, timeMax: timeMin })
+        .expect(400);
+
+      expect(planServSpy).toHaveBeenCalledTimes(0);
+      expect(request.body).toEqual({
+        ...result,
+        timestamp: request.body.timestamp,
+      });
+    });
+
+    it('expect failure response with invalid time query (Empty)', async () => {
+      const planServSpy = jest
+        .spyOn(planService, 'getPlans')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Service의 getPlans가 실행되어선 안됩니다.',
+          ),
+        );
+      const result = {
+        error: 'Bad Request',
+        statusCode: 400,
+        success: false,
+        message: 'Validation failed (Date string is expected)',
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .get(`/plan`)
+        .query({})
         .expect(400);
 
       expect(planServSpy).toHaveBeenCalledTimes(0);

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -184,4 +184,36 @@ describe('PlanController', () => {
       expect(message).toBeInstanceOf(Array);
     });
   });
+
+  describe('Put /plan/:planId', () => {
+    it('expect success response with updating a plan', async () => {
+      const updatePlanReq = omitKey(
+        {
+          ...PLAN_STUB,
+          tags: PLAN_STUB.tags.map(({ name }) => name),
+        },
+        ['id', 'createdAt', 'updatedAt', 'user'],
+      );
+      const planRes = { ...PLAN_STUB };
+      const planServSpy = jest
+        .spyOn(planService, 'updatePlan')
+        .mockResolvedValue(planRes);
+      const result = {
+        success: true,
+        data: planRes,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .put(`/plan/${PLAN_STUB.id}`)
+        .send(updatePlanReq)
+        .expect(200);
+
+      expect(planServSpy).toHaveBeenCalledWith({
+        ...updatePlanReq,
+        planId: PLAN_STUB.id,
+        userId: USER_STUB.id,
+      });
+      expect(request.body).toEqual(result);
+    });
+  });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -215,5 +215,32 @@ describe('PlanController', () => {
       });
       expect(request.body).toEqual(result);
     });
+
+    it('expect failure response with invalid body (empty Body - nothing match)', async () => {
+      const planServSpy = jest
+        .spyOn(planService, 'updatePlan')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Service의 updatePlan이 실행되어선 안됩니다.',
+          ),
+        );
+      const result = {
+        error: 'Bad Request',
+        statusCode: 400,
+        success: false,
+        message: '일정을 수정하려면 적어도 유효한 값이 하나라도 있어야 합니다.',
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .put(`/plan/${PLAN_STUB.id}`)
+        .send({})
+        .expect(400);
+
+      expect(planServSpy).toHaveBeenCalledTimes(0);
+      expect(request.body).toEqual({
+        ...result,
+        timestamp: request.body.timestamp,
+      });
+    });
   });
 });

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -122,4 +122,37 @@ describe('PlanController', () => {
       });
     });
   });
+
+  describe('Post /plan', () => {
+    it('expect success response with creating a plan', async () => {
+      const createPlanReq = omitKey(
+        {
+          ...PLAN_STUB,
+          startTime: new Date(PLAN_STUB.startTime),
+          endTime: new Date(PLAN_STUB.endTime),
+          tags: PLAN_STUB.tags.map(({ name }) => name),
+        },
+        ['id', 'createdAt', 'updatedAt', 'user'],
+      );
+      const planRes = { ...PLAN_STUB };
+      const planServSpy = jest
+        .spyOn(planService, 'createPlan')
+        .mockResolvedValue(planRes);
+      const result = {
+        success: true,
+        data: planRes,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .post(`/plan`)
+        .send(createPlanReq)
+        .expect(201);
+
+      expect(planServSpy).toHaveBeenCalledWith({
+        ...createPlanReq,
+        userId: USER_STUB.id,
+      });
+      expect(request.body).toEqual(result);
+    });
+  });
 });

--- a/test/utils/omit-key.ts
+++ b/test/utils/omit-key.ts
@@ -1,0 +1,13 @@
+function omitKey(target: object, strs: string[]) {
+  return strs.reduce(
+    (obj, key) => {
+      if (Object.hasOwnProperty.call(target, key)) {
+        delete obj[key];
+      }
+      return obj;
+    },
+    { ...target },
+  );
+}
+
+export { omitKey };


### PR DESCRIPTION
* Closes #38 
* Closes #39 

## ✨ **구현 기능 명세**

- Plan Controller Test 구현
- Plan Controller API 실제 구현
    - 조회 ( method: GET, url: /plan, query: `{ timeMin: Date, timeMax: Date }` )
    - 추가 ( method: POST, url: /plan )
        ```json
        body: {
            "title": "string",
            "description": "string",
            "isAllDay": true,
            "type": "string",
            "startTime": "2023-03-31T07:58:49.247Z",
            "endTime": "2023-03-31T07:58:49.247Z",
            "color": "#52d681",
            "categoryId": 100,
            "tags": 100
        }
        ```
    - 수정 ( method: PUT, url: /plan/:planId )
        ```json
        body: {
            "title": "내일 목표",
            "description": "이 일정은 지켜지지 않아도 된다.",
            "color": "#52d681",
            "isAllDay": true,
            "type": "event",
            "startTime": "2023-03-07T06:38:06.785Z",
            "endTime": null,
            "categoryId": 100,
            "tags": [
                "태그1",
                "태그2"
            ]
        }
        ```
    - 삭제 ( method :DELETE, url: /plan/:planId )

## 🎁 **주목할 점**

- Validation Pipe를 이용해서 `ParseDatePipe`라는 파이프를 생성, 이를 `query`로 받을 때 date 객체로서 받을 수 있도록 진행했습니다.
- `app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));` 코드를 이용해서 whitelist 를 추가했습니다.
    - 이제 원하지 않은 값을 Dto를 통해 filtering하고 받지 않습니다.

## 😭 **어려웠던 점**

API 선언 및 데이터 설정이 너무 다른 것들과 연관되어 있어서 맞추기 어려웠습니다,,

## 🌄 **스크린샷**

![image](https://user-images.githubusercontent.com/55688122/229051513-5896f9ee-cb8f-490f-9522-693cb8db1938.png)
