### PR TITLE
Plan Service 테스팅 & 구현 및 E2E Testing 으로 Plan 동작 확인

### DIFF
--- a/src/api/category/category.module.ts
+++ b/src/api/category/category.module.ts
@@ -10,5 +10,6 @@ import { CategoryService } from './category.service';
   imports: [TypeOrmExModule.forFeature([CategoryRepository])],
   controllers: [CategoryController],
   providers: [CategoryService],
+  exports: [CategoryService],
 })
 export class CategoryModule {}

--- a/src/api/category/category.repository.ts
+++ b/src/api/category/category.repository.ts
@@ -16,6 +16,7 @@ export class CategoryRepository extends Repository<CategoryEntity> {
     const category = await this.findOne({
       where: { id },
       select: { user: { id: true } },
+      relations: { user: true },
     });
 
     return category?.user.id ?? null;

--- a/src/api/category/category.repository.ts
+++ b/src/api/category/category.repository.ts
@@ -12,6 +12,15 @@ import { CATEGORY_SELECT } from '@/utils/constants';
 
 @CustomRepository(CategoryEntity)
 export class CategoryRepository extends Repository<CategoryEntity> {
+  async findOnlyUserId(id: number): Promise<number> {
+    const category = await this.findOne({
+      where: { id },
+      select: { user: { id: true } },
+    });
+
+    return category?.user.id ?? null;
+  }
+
   async findCategoryById({
     userId,
     categoryId,

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -25,8 +25,15 @@ export class CategoryService {
     categoryId,
   }: ICheckUserOwnCategoryArgs): Promise<void> {
     const categoryUserID = await this.categoryRepo.findOnlyUserId(categoryId);
-    if (!categoryUserID || userId !== categoryUserID) {
-      throw new ForbiddenException('유저가 조작할 수 없는 카테고리 입니다');
+    if (!categoryUserID) {
+      throw new ConflictException(
+        `존재하지 않는 카테고리입니다: ${categoryId}`,
+      );
+    }
+    if (userId !== categoryUserID) {
+      throw new ForbiddenException(
+        `유저가 조작할 수 없는 카테고리 입니다: ${categoryId}`,
+      );
     }
   }
 

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -30,6 +30,13 @@ export class CategoryService {
     }
   }
 
+  async checkHasCategory(id: number): Promise<void> {
+    const hasCategory = await this.categoryRepo.exist({ where: { id } });
+    if (!hasCategory) {
+      throw new ConflictException(`존재하지 않는 카테고리입니다 : ${id}`);
+    }
+  }
+
   async readCategory(userId: number): Promise<CategoryResDto[]> {
     return mapToHexColor(await this.categoryRepo.readCategory(userId));
   }

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -1,5 +1,6 @@
 import {
   ConflictException,
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
 } from '@nestjs/common';
@@ -8,6 +9,7 @@ import { Transactional } from 'typeorm-transactional';
 import { CategoryRepository } from '@/api/category/category.repository';
 import { CategoryResDto } from '@/dto/category';
 import {
+  ICheckUserOwnCategoryArgs,
   ICreateCategoryArgs,
   IDeleteCategoryArgs,
   IUpdateCategoryArgs,
@@ -17,6 +19,16 @@ import { mapToHexColor } from '@/utils/color-converter';
 @Injectable()
 export class CategoryService {
   constructor(private readonly categoryRepo: CategoryRepository) {}
+
+  async checkUserOwnCategory({
+    userId,
+    categoryId,
+  }: ICheckUserOwnCategoryArgs): Promise<void> {
+    const categoryUserID = await this.categoryRepo.findOnlyUserId(categoryId);
+    if (!categoryUserID || userId !== categoryUserID) {
+      throw new ForbiddenException('유저가 조작할 수 없는 카테고리 입니다');
+    }
+  }
 
   async readCategory(userId: number): Promise<CategoryResDto[]> {
     return mapToHexColor(await this.categoryRepo.readCategory(userId));

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -108,16 +108,15 @@ export class CategoryService {
   async deleteCategory(
     deleteCategoryArgs: IDeleteCategoryArgs,
   ): Promise<CategoryResDto> {
+    await this.checkUserOwnCategory(deleteCategoryArgs);
+
     const category = await this.categoryRepo.findCategoryById(
       deleteCategoryArgs,
     );
-    if (!category) {
-      throw new ConflictException('Category does not exist');
-    }
 
     if (!(await this.categoryRepo.deleteCategory(deleteCategoryArgs))) {
       throw new InternalServerErrorException(
-        'There is an error in deleting category',
+        '카테고리를 삭제하던 도중 에러가 발생했습니다. \n 삭제 요청을 취소합니다.',
       );
     }
     return mapToHexColor(category);

--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -24,13 +24,13 @@ export class CategoryService {
     userId,
     categoryId,
   }: ICheckUserOwnCategoryArgs): Promise<void> {
-    const categoryUserID = await this.categoryRepo.findOnlyUserId(categoryId);
-    if (!categoryUserID) {
+    const categoryUserId = await this.categoryRepo.findOnlyUserId(categoryId);
+    if (!categoryUserId) {
       throw new ConflictException(
         `존재하지 않는 카테고리입니다: ${categoryId}`,
       );
     }
-    if (userId !== categoryUserID) {
+    if (userId !== categoryUserId) {
       throw new ForbiddenException(
         `유저가 조작할 수 없는 카테고리 입니다: ${categoryId}`,
       );

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -24,7 +24,7 @@ import {
 import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
 import { PlanCreateReqDto, PlanResDto, PlanUpdateReqDto } from '@/dto/plan';
-import { UserEntity } from '@/entities';
+import { TTokenUser } from '@/types';
 
 import { PlanService } from './plan.service';
 
@@ -59,7 +59,7 @@ export class PlanController {
   async getPlans(
     @Query('timemin', ParseDatePipe) timeMin: Date,
     @Query('timemax', ParseDatePipe) timeMax: Date,
-    @User() user: UserEntity,
+    @User() user: TTokenUser,
   ) {
     if (timeMin > timeMax) {
       throw new BadRequestException(
@@ -83,7 +83,7 @@ export class PlanController {
   @Post('/')
   async createPlan(
     @Body() createPlanReqDto: PlanCreateReqDto,
-    @User() user: UserEntity,
+    @User() user: TTokenUser,
   ) {
     return this.planService.createPlan({
       ...createPlanReqDto,
@@ -112,7 +112,7 @@ export class PlanController {
   async updatePlan(
     @Param('planId', ParseIntPipe) planId: number,
     @Body() updatePlanReqDto: PlanUpdateReqDto,
-    @User() user: UserEntity,
+    @User() user: TTokenUser,
   ) {
     if (Object.keys(updatePlanReqDto).length === 0) {
       throw new BadRequestException(
@@ -145,7 +145,7 @@ export class PlanController {
   @Delete('/:planId')
   async deletePlan(
     @Param('planId', ParseIntPipe) planId: number,
-    @User() user: UserEntity,
+    @User() user: TTokenUser,
   ) {
     return this.planService.deletePlan({ planId, userId: user.id });
   }

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -10,10 +10,20 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+} from '@nestjs/swagger';
 
 import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
-import { PlanCreateReqDto, PlanUpdateReqDto } from '@/dto/plan';
+import { PlanCreateReqDto, PlanResDto, PlanUpdateReqDto } from '@/dto/plan';
 import { UserEntity } from '@/entities';
 
 import { PlanService } from './plan.service';
@@ -22,6 +32,29 @@ import { PlanService } from './plan.service';
 export class PlanController {
   constructor(private readonly planService: PlanService) {}
 
+  @ApiOperation({
+    summary: '원하는 날짜의 일정 조회',
+  })
+  @ApiQuery({
+    name: 'timemin',
+    type: Date,
+    example: '2023-04-01T00:00:00.000Z',
+    required: true,
+  })
+  @ApiQuery({
+    name: 'timemax',
+    type: Date,
+    example: '2023-05-01T00:00:00.000Z',
+    required: true,
+  })
+  @ApiOkResponse({
+    description: '일정 조회 성공',
+    type: PlanResDto,
+    isArray: true,
+  })
+  @ApiBadRequestResponse({
+    description: 'timemin query 값이 timemax query 값보다 이후일 때',
+  })
   @Get('/')
   async getPlans(
     @Query('timemin', ParseDatePipe) timeMin: Date,
@@ -37,6 +70,16 @@ export class PlanController {
     return this.planService.getPlans({ timeMin, timeMax, userId: user.id });
   }
 
+  @ApiOperation({
+    summary: '새로운 일정 추가',
+  })
+  @ApiCreatedResponse({
+    description: '일정 생성 성공',
+    type: PlanResDto,
+  })
+  @ApiConflictResponse({
+    description: '연결하고자 하는 카테고리 아이디가 존재하지 않는 경우',
+  })
   @Post('/')
   async createPlan(
     @Body() createPlanReqDto: PlanCreateReqDto,
@@ -48,6 +91,23 @@ export class PlanController {
     });
   }
 
+  @ApiOperation({
+    summary: '일정 수정',
+  })
+  @ApiOkResponse({
+    description: '일정 수정 성공',
+    type: PlanResDto,
+  })
+  @ApiBadRequestResponse({
+    description: '바꾸려는 일정 값이(Body 혹은 planId 값) 존재하지 않을 때',
+  })
+  @ApiConflictResponse({
+    description:
+      '일정 아이디가 존재하지 않거나 카테고리 아이디가 존재하지 않는 경우',
+  })
+  @ApiForbiddenResponse({
+    description: '일정 혹은 카테고리가 유저가 소유한 것이 아닐 경우',
+  })
   @Put('/:planId')
   async updatePlan(
     @Param('planId', ParseIntPipe) planId: number,
@@ -66,6 +126,22 @@ export class PlanController {
     });
   }
 
+  @ApiOperation({
+    summary: '일정 삭제',
+  })
+  @ApiOkResponse({
+    description: '일정 삭제 성공',
+    type: PlanResDto,
+  })
+  @ApiConflictResponse({
+    description: '일정 아이디가 존재하지 않을 경우',
+  })
+  @ApiForbiddenResponse({
+    description: '일정이 유저가 소유한 것이 아닐 경우',
+  })
+  @ApiInternalServerErrorResponse({
+    description: '일정 삭제가 데이터베이스 오류로 실패된 경우',
+  })
   @Delete('/:planId')
   async deletePlan(
     @Param('planId', ParseIntPipe) planId: number,

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -61,7 +61,7 @@ export class PlanController {
     }
     return this.planService.updatePlan({
       ...updatePlanReqDto,
-      planId,
+      id: planId,
       userId: user.id,
     });
   }

--- a/src/api/plan/plan.module.ts
+++ b/src/api/plan/plan.module.ts
@@ -5,9 +5,15 @@ import { TypeOrmExModule } from '@/common/modules';
 import { PlanController } from './plan.controller';
 import { PlanRepository } from './plan.repository';
 import { PlanService } from './plan.service';
+import { CategoryModule } from '../category/category.module';
+import { TagModule } from '../tag/tag.module';
 
 @Module({
-  imports: [TypeOrmExModule.forFeature([PlanRepository])],
+  imports: [
+    TypeOrmExModule.forFeature([PlanRepository]),
+    CategoryModule,
+    TagModule,
+  ],
   controllers: [PlanController],
   providers: [PlanService],
 })

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -1,7 +1,17 @@
 import { Repository } from 'typeorm';
 
 import { CustomRepository } from '@/common/decorators';
+import { PlanResDto } from '@/dto/plan';
 import { PlanEntity } from '@/entities';
+import { PLAN_SELECT } from '@/utils/constants';
 
 @CustomRepository(PlanEntity)
-export class PlanRepository extends Repository<PlanEntity> {}
+export class PlanRepository extends Repository<PlanEntity> {
+  async findPlanById(id: number): Promise<PlanResDto> {
+    return await this.findOne({
+      where: { id },
+      select: PLAN_SELECT,
+      relations: { category: false, tags: true },
+    });
+  }
+}

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -26,11 +26,11 @@ export class PlanRepository extends Repository<PlanEntity> {
     return plan?.userId ?? null;
   }
 
-  findPlansBetweenDate({
+  async findPlansBetweenDate({
     timeMin,
     timeMax,
   }: IGetPlansArgs): Promise<PlanResDto[]> {
-    return this.find({
+    return await this.find({
       where: {
         startTime: Between(timeMin, timeMax),
       },

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -4,7 +4,7 @@ import { CustomRepository } from '@/common/decorators';
 import { PlanResDto } from '@/dto/plan';
 import { TagResDto } from '@/dto/tag';
 import { PlanEntity } from '@/entities';
-import { ICreatePlanArgs, IGetPlansArgs } from '@/types/args';
+import { ICreatePlanArgs, IGetPlansArgs, IUpdatePlanArgs } from '@/types/args';
 import { PLAN_SELECT } from '@/utils/constants';
 
 @CustomRepository(PlanEntity)
@@ -46,6 +46,17 @@ export class PlanRepository extends Repository<PlanEntity> {
 
     const { id } = await this.save(filteredPlan);
 
+    return await this.findPlanById(id);
+  }
+
+  async updatePlan({
+    id,
+    ...planData
+  }: Omit<IUpdatePlanArgs, 'tags'> & {
+    tags: TagResDto[];
+  }): Promise<PlanResDto> {
+    const data = this.create({ ...planData, id });
+    await this.save(data);
     return await this.findPlanById(id);
   }
 }

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -59,4 +59,9 @@ export class PlanRepository extends Repository<PlanEntity> {
     await this.save(data);
     return await this.findPlanById(id);
   }
+
+  async deletePlan(planId: number): Promise<boolean> {
+    const { affected } = await this.delete({ id: planId });
+    return !!affected;
+  }
 }

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -1,8 +1,9 @@
-import { Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 
 import { CustomRepository } from '@/common/decorators';
 import { PlanResDto } from '@/dto/plan';
 import { PlanEntity } from '@/entities';
+import { IGetPlansArgs } from '@/types/args';
 import { PLAN_SELECT } from '@/utils/constants';
 
 @CustomRepository(PlanEntity)
@@ -22,5 +23,18 @@ export class PlanRepository extends Repository<PlanEntity> {
     });
 
     return plan?.userId ?? null;
+  }
+
+  findPlansBetweenDate({
+    timeMin,
+    timeMax,
+  }: IGetPlansArgs): Promise<PlanResDto[]> {
+    return this.find({
+      where: {
+        startTime: Between(timeMin, timeMax),
+      },
+      select: PLAN_SELECT,
+      relations: { tags: true },
+    });
   }
 }

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -2,8 +2,9 @@ import { Between, Repository } from 'typeorm';
 
 import { CustomRepository } from '@/common/decorators';
 import { PlanResDto } from '@/dto/plan';
+import { TagResDto } from '@/dto/tag';
 import { PlanEntity } from '@/entities';
-import { IGetPlansArgs } from '@/types/args';
+import { ICreatePlanArgs, IGetPlansArgs } from '@/types/args';
 import { PLAN_SELECT } from '@/utils/constants';
 
 @CustomRepository(PlanEntity)
@@ -36,5 +37,15 @@ export class PlanRepository extends Repository<PlanEntity> {
       select: PLAN_SELECT,
       relations: { tags: true },
     });
+  }
+
+  async createPlan(
+    planData: Omit<ICreatePlanArgs, 'tags'> & { tags: TagResDto[] },
+  ): Promise<PlanResDto> {
+    const filteredPlan = this.create(planData);
+
+    const { id } = await this.save(filteredPlan);
+
+    return await this.findPlanById(id);
   }
 }

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -14,4 +14,13 @@ export class PlanRepository extends Repository<PlanEntity> {
       relations: { category: false, tags: true },
     });
   }
+
+  async findOnlyUserId(id: number): Promise<number> {
+    const plan = await this.findOne({
+      where: { id },
+      select: { userId: true },
+    });
+
+    return plan?.userId ?? null;
+  }
 }

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -37,6 +37,13 @@ export class PlanService {
     }
   }
 
+  async checkHasPlan(id: number): Promise<void> {
+    const hasPlan = await this.planRepo.exist({ where: { id } });
+    if (!hasPlan) {
+      throw new ConflictException(`존재하지 않는 일정입니다 : ${id}`);
+    }
+  }
+
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
     return [];
   }

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
+import { CategoryService } from '@/api/category/category.service';
+import { TagService } from '@/api/tag/tag.service';
 import { PlanResDto } from '@/dto/plan';
 import {
   ICreatePlanArgs,
@@ -12,7 +14,11 @@ import { PlanRepository } from './plan.repository';
 
 @Injectable()
 export class PlanService {
-  constructor(private readonly planRepo: PlanRepository) {}
+  constructor(
+    private readonly planRepo: PlanRepository,
+    private readonly categoryService: CategoryService,
+    private readonly tagService: TagService,
+  ) {}
 
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
     return [];

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -14,6 +14,7 @@ import {
   IGetPlansArgs,
   IUpdatePlanWithTagsArgs,
 } from '@/types/args';
+import { mapToHexColor } from '@/utils/color-converter';
 
 import { PlanRepository } from './plan.repository';
 
@@ -45,7 +46,7 @@ export class PlanService {
   }
 
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
-    return [];
+    return mapToHexColor(await this.planRepo.findPlansBetweenDate(data));
   }
 
   async createPlan(data: ICreatePlanArgs): Promise<PlanResDto> {

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -1,9 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
 
 import { CategoryService } from '@/api/category/category.service';
 import { TagService } from '@/api/tag/tag.service';
 import { PlanResDto } from '@/dto/plan';
 import {
+  ICheckUserOwnPlan,
   ICreatePlanArgs,
   IDeletePlanArgs,
   IGetPlansArgs,
@@ -19,6 +24,18 @@ export class PlanService {
     private readonly categoryService: CategoryService,
     private readonly tagService: TagService,
   ) {}
+
+  async checkUserOwnPlan({ userId, planId }: ICheckUserOwnPlan): Promise<void> {
+    const planUserId = await this.planRepo.findOnlyUserId(planId);
+    if (!planUserId) {
+      throw new ConflictException(`존재하지 않는 일정입니다: ${planId}`);
+    }
+    if (planUserId !== userId) {
+      throw new ForbiddenException(
+        `유저가 조작할 수 없는 일정입니다: ${planId}`,
+      );
+    }
+  }
 
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
     return [];

--- a/src/api/tag/tag.module.ts
+++ b/src/api/tag/tag.module.ts
@@ -10,5 +10,6 @@ import { TagService } from './tag.service';
   imports: [TypeOrmExModule.forFeature([TagRepository])],
   controllers: [TagController],
   providers: [TagService],
+  exports: [TagService],
 })
 export class TagModule {}

--- a/src/api/tag/tag.repository.ts
+++ b/src/api/tag/tag.repository.ts
@@ -7,6 +7,29 @@ import { CreateTagArgs, DeleteTagArgs, UpdateTagArgs } from '@/types/args';
 
 @CustomRepository(TagEntity)
 export class TagRepository extends Repository<TagEntity> {
+  async findTagWithPlans({
+    tagId,
+    userId,
+  }: {
+    tagId: number;
+    userId: number;
+  }): Promise<TagResDto & { plans: { id: number }[] }> {
+    return this.findOne({
+      where: {
+        id: tagId,
+        user: { id: userId },
+      },
+      select: {
+        id: true,
+        name: true,
+        plans: {
+          id: true,
+        },
+      },
+      relations: { plans: true },
+    });
+  }
+
   async findTagById({
     tagId,
     userId,

--- a/src/api/tag/tag.service.ts
+++ b/src/api/tag/tag.service.ts
@@ -55,7 +55,7 @@ export class TagService {
     if (!tagWithPlans) return null;
 
     const { plans, ...tagData } = tagWithPlans;
-    if (tagWithPlans && plans.length === 0) {
+    if (plans.length === 0) {
       await this.tagRepo.deleteTag(deleteTagArgs);
     }
 

--- a/src/api/tag/tag.service.ts
+++ b/src/api/tag/tag.service.ts
@@ -46,4 +46,19 @@ export class TagService {
     }
     return tag;
   }
+
+  async deleteTagIfNotReferenced(
+    deleteTagArgs: DeleteTagArgs,
+  ): Promise<TagResDto | null> {
+    const tagWithPlans = await this.tagRepo.findTagWithPlans(deleteTagArgs);
+
+    if (!tagWithPlans) return null;
+
+    const { plans, ...tagData } = tagWithPlans;
+    if (tagWithPlans && plans.length === 0) {
+      await this.tagRepo.deleteTag(deleteTagArgs);
+    }
+
+    return tagData;
+  }
 }

--- a/src/common/decorators/date-type.decorator.ts
+++ b/src/common/decorators/date-type.decorator.ts
@@ -27,6 +27,10 @@ export function IsDateType(validationOptions?: ValidationOptions) {
 
 export function TransformDate(options?: TransformOptions) {
   return Transform(({ value }) => {
+    if (value === null) {
+      return null;
+    }
+
     const returnValue = new Date(value);
     return isNaN(returnValue.getTime()) ? null : returnValue;
   }, options);

--- a/src/dto/plan/plan-create-req.dto.ts
+++ b/src/dto/plan/plan-create-req.dto.ts
@@ -1,4 +1,5 @@
 import { ApiPropertyOptional, PickType } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
@@ -24,6 +25,7 @@ class PlanCreateReqDto extends PickType(PlanEntity, [
   })
   @IsOptional()
   @IsHexColor()
+  @Transform(({ value }) => value.replace('#', ''))
   color?: string;
 
   @ApiPropertyOptional({

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -7,6 +7,7 @@ import { PlanEntity } from '@/entities';
 class PlanResDto extends OmitType(PlanEntity, [
   'createdAt',
   'updatedAt',
+  'userId',
   'user',
   'tags',
   'category',
@@ -20,6 +21,7 @@ class PlanResDto extends OmitType(PlanEntity, [
 
   @ApiProperty({
     description: '일정이 가지고 있는 태그 객체',
+    example: ['태그1', '태그2'],
   })
   @IsArray()
   @ArrayMaxSize(5)

--- a/src/dto/plan/plan-update-req.dto.ts
+++ b/src/dto/plan/plan-update-req.dto.ts
@@ -1,4 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsArray,
@@ -39,6 +40,7 @@ class PlanUpdateReqDto {
   })
   @IsHexColor()
   @IsOptional()
+  @Transform(({ value }) => value.replace('#', ''))
   color?: string;
 
   @ApiPropertyOptional({

--- a/src/entities/plan.entity.ts
+++ b/src/entities/plan.entity.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsBoolean,
   IsOptional,
@@ -33,20 +34,26 @@ export enum PLAN_TYPE {
 
 @Entity('plan_tb')
 export class PlanEntity extends DefaultEntity {
-  @ApiProperty()
+  @ApiProperty({
+    example: '제목!!',
+  })
   @Column({ type: 'varchar', length: 30 })
   @IsNotEmpty()
   @IsString()
   @MaxLength(30)
   title!: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: '나만의 설명',
+  })
   @Column({ type: 'text', nullable: true })
   @IsOptional()
   @IsString()
   description?: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: '#52d681',
+  })
   @Column({
     type: 'char',
     length: 6,
@@ -54,52 +61,68 @@ export class PlanEntity extends DefaultEntity {
   })
   @IsNotEmpty()
   @IsHexColor()
+  @Transform(({ value }) => value.replace('#', ''))
   color!: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: true,
+  })
   @Column({ type: 'boolean', default: true })
   @IsNotEmpty()
   @IsBoolean()
   isAllDay: boolean;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: 'task',
+  })
   @Column({ type: 'enum', enum: PLAN_TYPE })
   @IsNotEmpty()
   @IsEnum(PLAN_TYPE)
   type!: PLAN_TYPE;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: '2023-04-05T04:41:19.933Z',
+  })
   @Column({ type: 'datetime' })
   @IsNotEmpty()
   @IsDateType()
   @TransformDate()
   startTime!: Date;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: '2023-04-05T04:41:19.933Z',
+  })
   @Column({ type: 'datetime', nullable: true })
   @IsOptional()
   @IsDateType()
   @TransformDate()
   endTime?: Date;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: 1,
+  })
+  @Column({ type: 'int' })
+  @IsNumber()
+  userId!: number;
+
   @ManyToOne(() => UserEntity, { onDelete: 'CASCADE', cascade: true })
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({ name: 'userId' })
   user!: UserEntity;
 
+  @ApiProperty({
+    example: 1,
+  })
   @Column({ type: 'int' })
   @IsNumber()
   categoryId!: number;
 
-  @ApiProperty()
-  @ManyToOne(() => CategoryEntity, (category) => category.plans, {
-    onDelete: 'CASCADE',
-    cascade: true,
-  })
+  @ManyToOne(() => CategoryEntity, (category) => category.plans)
   @JoinColumn({ name: 'categoryId' })
   category!: CategoryEntity;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: ['태그1', '태그2'],
+  })
   @ManyToMany(() => TagEntity, (tag) => tag.plans, { cascade: true })
   @JoinTable({
     joinColumn: { name: 'plan_id' },

--- a/src/types/args/category.ts
+++ b/src/types/args/category.ts
@@ -1,5 +1,10 @@
 import { CategoryResDto } from '@/dto/category';
 
+interface ICheckUserOwnCategoryArgs {
+  userId: number;
+  categoryId: number;
+}
+
 interface ICategoryInfo extends Omit<CategoryResDto, 'color'> {
   color: string;
 }
@@ -23,6 +28,7 @@ interface IDeleteCategoryArgs {
 }
 
 export {
+  ICheckUserOwnCategoryArgs,
   ICreateCategoryArgs,
   IUpdateCategoryArgs,
   IDeleteCategoryArgs,

--- a/src/types/args/plan.ts
+++ b/src/types/args/plan.ts
@@ -1,5 +1,10 @@
 import { PlanCreateReqDto, PlanUpdateReqDto } from '@/dto/plan';
 
+interface ICheckUserOwnPlan {
+  userId: number;
+  planId: number;
+}
+
 interface IGetPlansArgs {
   userId: number;
   timeMin: Date;
@@ -10,13 +15,13 @@ interface ICreatePlanArgs extends PlanCreateReqDto {
   userId: number;
 }
 
-interface IUpdatePlanArgs extends Omit<PlanUpdateReqDto, 'tags'> {
+interface IUpdatePlanArgs extends PlanUpdateReqDto {
   id: number;
 }
 
 interface IUpdatePlanWithTagsArgs extends PlanUpdateReqDto {
   userId: number;
-  planId: number;
+  id: number;
 }
 
 interface IDeletePlanArgs {
@@ -25,6 +30,7 @@ interface IDeletePlanArgs {
 }
 
 export {
+  ICheckUserOwnPlan,
   IGetPlansArgs,
   ICreatePlanArgs,
   IUpdatePlanArgs,

--- a/src/utils/color-converter.ts
+++ b/src/utils/color-converter.ts
@@ -1,6 +1,9 @@
 import { THexColor } from '@/types';
 
-const strToHexColor = (color: string): THexColor => `#${color}`;
+const strToHexColor = (color: string): THexColor => {
+  if (color[0] === '#') return color as THexColor;
+  return `#${color}`;
+};
 
 const mapToHexColor = <
   IType extends { color: string },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,9 +10,26 @@ const CATEGORY_SELECT = {
   color: true,
 };
 
+const PLAN_SELECT = {
+  id: true,
+  title: true,
+  description: true,
+  color: true,
+  isAllDay: true,
+  type: true,
+  startTime: true,
+  endTime: true,
+  categoryId: true,
+  tags: {
+    id: true,
+    name: true,
+  },
+};
+
 export {
   PLANDAR_CUSTOM_REPSOITORY,
   ENV_PROVIDER,
   IS_PUBLIC_KEY,
   CATEGORY_SELECT,
+  PLAN_SELECT,
 };

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -567,31 +567,6 @@ describe('CategoryService', () => {
     });
   });
 
-  describe('fail delete', () => {
-    it('try to delete not existed category', async () => {
-      // given
-      const userId = stubCategory[0].user.id;
-      const categoryId = stubCategory[0].id;
-
-      const categoryRepoFind = jest
-        .spyOn(categoryRepo, 'findCategoryById')
-        .mockResolvedValue(null);
-
-      try {
-        // when
-        await categoryService.deleteCategory({ userId, categoryId });
-      } catch (e) {
-        // then
-        expect(e).toBeInstanceOf(ConflictException);
-      }
-
-      expect(categoryRepoFind).toHaveBeenCalledWith({
-        userId,
-        categoryId,
-      });
-    });
-  });
-
   describe('success delete', () => {
     it('success delete category', async () => {
       // given
@@ -613,6 +588,9 @@ describe('CategoryService', () => {
         id: categoryId,
         color: `#${color}`,
       };
+      const categoryCheckUserOwnCategorySpy = jest
+        .spyOn(categoryService, 'checkUserOwnCategory')
+        .mockResolvedValue(undefined);
       const categoryFindById = jest
         .spyOn(categoryRepo, 'findCategoryById')
         .mockResolvedValue(repoRet);
@@ -624,6 +602,7 @@ describe('CategoryService', () => {
       const category = await categoryService.deleteCategory(params);
 
       // then
+      expect(categoryCheckUserOwnCategorySpy).toHaveBeenCalledWith(params);
       expect(categoryFindById).toHaveBeenCalledWith(params);
       expect(categoryRepoSpy).toHaveBeenCalledWith(params);
       expect(category).toEqual(shouldBe);

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -43,6 +43,26 @@ describe('CategoryService', () => {
       expect(categoryRepoSpy).toHaveBeenCalledWith(args.categoryId);
     });
 
+    it(`expect throw error when category does not exist`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        categoryId: STUB_CATEGORY[0].id,
+      };
+      const categoryRepoSpy = jest
+        .spyOn(categoryRepo, 'findOnlyUserId')
+        .mockResolvedValue(null);
+
+      try {
+        await categoryService.checkUserOwnCategory(args);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
+        expect(categoryRepoSpy).toHaveBeenCalledWith(args.categoryId);
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(typeof error.message).toBe('string');
+      }
+    });
+
     it(`expect throw error when category's userId is not same with userId`, async () => {
       const args = {
         userId: USER_STUB.id,

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -64,6 +64,22 @@ describe('CategoryService', () => {
     });
   });
 
+  describe('checkHasCategory', () => {
+    it(`should pass if categoryId is existing in database`, async () => {
+      const categoryId = STUB_CATEGORY[0].id;
+      const categoryRepoSpy = jest
+        .spyOn(categoryRepo, 'exist')
+        .mockResolvedValue(true);
+
+      await categoryService.checkHasCategory(categoryId);
+
+      expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
+      expect(categoryRepoSpy).toHaveBeenCalledWith({
+        where: { id: categoryId },
+      });
+    });
+  });
+
   describe('success read', () => {
     it('return category list', async () => {
       // given

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -5,6 +5,7 @@ import { CategoryService } from '@/api/category/category.service';
 import createTestingModule from 'test/utils/create-testing-module';
 
 import { STUB_CATEGORY } from './stub';
+import { USER_STUB } from '../user/stub';
 
 describe('CategoryService', () => {
   const stubCategory = STUB_CATEGORY;
@@ -24,6 +25,23 @@ describe('CategoryService', () => {
   it('Check defining Modules', () => {
     expect(categoryRepo).toBeDefined();
     expect(categoryService).toBeDefined();
+  });
+
+  describe('checkUserOwnCategory', () => {
+    it(`should pass - userId & category's userId are same`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        categoryId: STUB_CATEGORY[0].id,
+      };
+      const categoryRepoSpy = jest
+        .spyOn(categoryRepo, 'findOnlyUserId')
+        .mockResolvedValue(args.userId);
+
+      await categoryService.checkUserOwnCategory(args);
+
+      expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
+      expect(categoryRepoSpy).toHaveBeenCalledWith(args.categoryId);
+    });
   });
 
   describe('success read', () => {

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -78,6 +78,25 @@ describe('CategoryService', () => {
         where: { id: categoryId },
       });
     });
+
+    it(`expect throw conflict error if categoryId is not existed in database`, async () => {
+      const categoryId = STUB_CATEGORY[0].id;
+      const categoryRepoSpy = jest
+        .spyOn(categoryRepo, 'exist')
+        .mockResolvedValue(false);
+
+      try {
+        await categoryService.checkHasCategory(categoryId);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
+        expect(categoryRepoSpy).toHaveBeenCalledWith({
+          where: { id: categoryId },
+        });
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(typeof error.message).toBe('string');
+      }
+    });
   });
 
   describe('success read', () => {

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
 
 import { CategoryRepository } from '@/api/category/category.repository';
 import { CategoryService } from '@/api/category/category.service';
@@ -41,6 +41,26 @@ describe('CategoryService', () => {
 
       expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
       expect(categoryRepoSpy).toHaveBeenCalledWith(args.categoryId);
+    });
+
+    it(`expect throw error when category's userId is not same with userId`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        categoryId: STUB_CATEGORY[0].id,
+      };
+      const categoryRepoSpy = jest
+        .spyOn(categoryRepo, 'findOnlyUserId')
+        .mockResolvedValue(Infinity);
+
+      try {
+        await categoryService.checkUserOwnCategory(args);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(categoryRepoSpy).toHaveBeenCalledTimes(1);
+        expect(categoryRepoSpy).toHaveBeenCalledWith(args.categoryId);
+        expect(error).toBeInstanceOf(ForbiddenException);
+        expect(typeof error.message).toBe('string');
+      }
     });
   });
 

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -132,7 +132,7 @@ describe('PlanController', () => {
           endTime: new Date(PLAN_STUB.endTime),
           tags: PLAN_STUB.tags.map(({ name }) => name),
         },
-        ['id', 'createdAt', 'updatedAt', 'user'],
+        ['id'],
       );
       const planRes = { ...PLAN_STUB };
       const planServSpy = jest
@@ -193,7 +193,7 @@ describe('PlanController', () => {
           tags: PLAN_STUB.tags.map(({ name }) => name),
           startTime: new Date(PLAN_STUB.startTime),
         },
-        ['id', 'createdAt', 'updatedAt', 'user'],
+        ['id'],
       );
       const planRes = { ...PLAN_STUB };
       const planServSpy = jest

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -191,6 +191,7 @@ describe('PlanController', () => {
         {
           ...PLAN_STUB,
           tags: PLAN_STUB.tags.map(({ name }) => name),
+          startTime: new Date(PLAN_STUB.startTime),
         },
         ['id', 'createdAt', 'updatedAt', 'user'],
       );

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -55,7 +55,7 @@ describe('PlanController', () => {
 
       const request = await testRequest(app.getHttpServer())
         .get(`/plan`)
-        .query({ timeMin, timeMax })
+        .query({ timemin: timeMin, timemax: timeMax })
         .expect(200);
 
       expect(planServSpy).toHaveBeenCalledWith({
@@ -85,7 +85,7 @@ describe('PlanController', () => {
 
       const request = await testRequest(app.getHttpServer())
         .get(`/plan`)
-        .query({ timeMin: timeMax, timeMax: timeMin })
+        .query({ timemin: timeMax, timemax: timeMin })
         .expect(400);
 
       expect(planServSpy).toHaveBeenCalledTimes(0);

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -211,7 +211,7 @@ describe('PlanController', () => {
 
       expect(planServSpy).toHaveBeenCalledWith({
         ...updatePlanReq,
-        planId: PLAN_STUB.id,
+        id: PLAN_STUB.id,
         userId: USER_STUB.id,
       });
       expect(request.body).toEqual(result);

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -230,4 +230,47 @@ describe('PlanService', () => {
       expect(plan).toEqual(result);
     });
   });
+
+  describe('updatePlan', () => {
+    it('should update plan without categoryId & tags and return', async () => {
+      const planData = omitKey(
+        {
+          ...PLAN_STUB,
+          tags: [],
+          userId: USER_STUB.id,
+        },
+        ['categoryId'],
+      );
+      const result = { ...PLAN_STUB_WITH_COLOR, tags: [], categoryId: null };
+      const planCheckUserOwnPlanSpy = jest
+        .spyOn(planService, 'checkUserOwnPlan')
+        .mockResolvedValue(undefined);
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'checkUserOwnCategory')
+        .mockRejectedValue(
+          new Error(
+            'categoryService - checkUserOwnCategory : 실행되어선 안되는 함수입니다.',
+          ),
+        );
+      const tagServSpy = jest
+        .spyOn(tagService, 'createTag')
+        .mockRejectedValue(
+          new Error('tagService - createTag : 실행되어선 안되는 함수입니다.'),
+        );
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'updatePlan')
+        .mockResolvedValue({ ...result, color: PLAN_STUB.color });
+
+      const plans = await planService.updatePlan(planData);
+
+      expect(planCheckUserOwnPlanSpy).toHaveBeenCalledTimes(1);
+      expect(categoryServSpy).toHaveBeenCalledTimes(0);
+      expect(tagServSpy).toHaveBeenCalledTimes(0);
+      expect(planRepoSpy).toHaveBeenCalledTimes(1);
+      expect(planRepoSpy).toHaveBeenCalledWith({
+        ...planData,
+      });
+      expect(plans).toEqual(result);
+    });
+  });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -88,4 +88,18 @@ describe('PlanService', () => {
       }
     });
   });
+
+  describe('checkHasPlan', () => {
+    it(`should pass if planId is existing in database`, async () => {
+      const planId = PLAN_STUB.id;
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'exist')
+        .mockResolvedValue(true);
+
+      await planService.checkHasPlan(planId);
+
+      expect(planRepoSpy).toHaveBeenCalledTimes(1);
+      expect(planRepoSpy).toHaveBeenCalledWith({ where: { id: planId } });
+    });
+  });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -2,6 +2,8 @@ import { CategoryService } from '@/api/category/category.service';
 import { PlanRepository } from '@/api/plan/plan.repository';
 import { PlanService } from '@/api/plan/plan.service';
 import { TagService } from '@/api/tag/tag.service';
+import { PLAN_STUB } from 'test/api/plan/stub';
+import { USER_STUB } from 'test/api/user/stub';
 import createTestingModule from 'test/utils/create-testing-module';
 
 describe('PlanService', () => {
@@ -26,5 +28,22 @@ describe('PlanService', () => {
     expect(categoryService).toBeDefined();
     expect(tagService).toBeDefined();
     expect(planService).toBeDefined();
+  });
+
+  describe('checkUserOwnPlan', () => {
+    it(`should pass - userId & plan's userId are same`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        planId: PLAN_STUB.id,
+      };
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'findOnlyUserId')
+        .mockResolvedValue(args.userId);
+
+      await planService.checkUserOwnPlan(args);
+
+      expect(planRepoSpy).toHaveBeenCalledTimes(1);
+      expect(planRepoSpy).toHaveBeenCalledWith(args.planId);
+    });
   });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -187,5 +187,47 @@ describe('PlanService', () => {
       });
       expect(plan).toEqual(result);
     });
+
+    it('should createPlan with category & tags and return new', async () => {
+      const newPlanData = {
+        ...PLAN_STUB,
+        tags: PLAN_STUB.tags.map(({ name }) => name),
+        userId: USER_STUB.id,
+      };
+      const result = { ...PLAN_STUB_WITH_COLOR };
+      const categoryServSpy = jest
+        .spyOn(categoryService, 'checkUserOwnCategory')
+        .mockResolvedValue(undefined);
+      const tagServSpy = jest
+        .spyOn(tagService, 'createTag')
+        .mockImplementation(async ({ tagName }) => ({
+          ...PLAN_STUB.tags.find(({ name }) => name === tagName),
+        }));
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'createPlan')
+        .mockResolvedValue({ ...PLAN_STUB });
+
+      const plan = await planService.createPlan(newPlanData);
+
+      expect(categoryServSpy).toHaveBeenCalledTimes(1);
+      expect(categoryServSpy).toHaveBeenCalledWith({
+        categoryId: newPlanData.categoryId,
+        userId: newPlanData.userId,
+      });
+      expect(tagServSpy).toHaveBeenCalledTimes(PLAN_STUB.tags.length);
+      newPlanData.tags.forEach((tagName) => {
+        expect(tagServSpy).toHaveBeenCalledWith({
+          tagName,
+          userId: newPlanData.userId,
+        });
+      });
+      expect(planRepoSpy).toHaveBeenCalledTimes(1);
+      expect(planRepoSpy).toHaveBeenCalledWith({
+        ...result,
+        color: PLAN_STUB.color,
+        userId: newPlanData.userId,
+      });
+      expect(plan).toEqual(result);
+    });
   });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -101,5 +101,22 @@ describe('PlanService', () => {
       expect(planRepoSpy).toHaveBeenCalledTimes(1);
       expect(planRepoSpy).toHaveBeenCalledWith({ where: { id: planId } });
     });
+
+    it(`expect throw conflict error if planId is not existed in database`, async () => {
+      const planId = PLAN_STUB.id;
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'exist')
+        .mockResolvedValue(false);
+
+      try {
+        await planService.checkHasPlan(planId);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(planRepoSpy).toHaveBeenCalledTimes(1);
+        expect(planRepoSpy).toHaveBeenCalledWith({ where: { id: planId } });
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(typeof error.message).toBe('string');
+      }
+    });
   });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -1,22 +1,30 @@
+import { CategoryService } from '@/api/category/category.service';
 import { PlanRepository } from '@/api/plan/plan.repository';
 import { PlanService } from '@/api/plan/plan.service';
+import { TagService } from '@/api/tag/tag.service';
 import createTestingModule from 'test/utils/create-testing-module';
 
 describe('PlanService', () => {
   let planRepository: PlanRepository;
   let planService: PlanService;
+  let categoryService: CategoryService;
+  let tagService: TagService;
 
   beforeEach(async () => {
     const moduleRef = await createTestingModule({
-      providers: [PlanService],
+      providers: [PlanService, CategoryService, TagService],
     });
 
     planRepository = moduleRef.get<PlanRepository>(PlanRepository);
+    categoryService = moduleRef.get<CategoryService>(CategoryService);
+    tagService = moduleRef.get<TagService>(TagService);
     planService = moduleRef.get<PlanService>(PlanService);
   });
 
   it('Check defining Modules', () => {
     expect(planRepository).toBeDefined();
+    expect(categoryService).toBeDefined();
+    expect(tagService).toBeDefined();
     expect(planService).toBeDefined();
   });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -1,3 +1,5 @@
+import { ConflictException } from '@nestjs/common';
+
 import { CategoryService } from '@/api/category/category.service';
 import { PlanRepository } from '@/api/plan/plan.repository';
 import { PlanService } from '@/api/plan/plan.service';
@@ -44,6 +46,26 @@ describe('PlanService', () => {
 
       expect(planRepoSpy).toHaveBeenCalledTimes(1);
       expect(planRepoSpy).toHaveBeenCalledWith(args.planId);
+    });
+
+    it(`expect throw error when plan does not exist`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        planId: PLAN_STUB.id,
+      };
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'findOnlyUserId')
+        .mockResolvedValue(null);
+
+      try {
+        await planService.checkUserOwnPlan(args);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(planRepoSpy).toHaveBeenCalledTimes(1);
+        expect(planRepoSpy).toHaveBeenCalledWith(args.planId);
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(typeof error.message).toBe('string');
+      }
     });
   });
 });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { ConflictException, ForbiddenException } from '@nestjs/common';
 
 import { CategoryService } from '@/api/category/category.service';
 import { PlanRepository } from '@/api/plan/plan.repository';
@@ -64,6 +64,26 @@ describe('PlanService', () => {
         expect(planRepoSpy).toHaveBeenCalledTimes(1);
         expect(planRepoSpy).toHaveBeenCalledWith(args.planId);
         expect(error).toBeInstanceOf(ConflictException);
+        expect(typeof error.message).toBe('string');
+      }
+    });
+
+    it(`expect throw error when plan's userId is not same with userId`, async () => {
+      const args = {
+        userId: USER_STUB.id,
+        planId: PLAN_STUB.id,
+      };
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'findOnlyUserId')
+        .mockResolvedValue(Infinity);
+
+      try {
+        await planService.checkUserOwnPlan(args);
+        expect('not to be execute this').toBe('throw Error');
+      } catch (error) {
+        expect(planRepoSpy).toHaveBeenCalledTimes(1);
+        expect(planRepoSpy).toHaveBeenCalledWith(args.planId);
+        expect(error).toBeInstanceOf(ForbiddenException);
         expect(typeof error.message).toBe('string');
       }
     });

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -4,7 +4,12 @@ import { CategoryService } from '@/api/category/category.service';
 import { PlanRepository } from '@/api/plan/plan.repository';
 import { PlanService } from '@/api/plan/plan.service';
 import { TagService } from '@/api/tag/tag.service';
-import { PLAN_STUB } from 'test/api/plan/stub';
+import {
+  PLAN_STUB,
+  PLAN_STUB_WITH_COLOR,
+  PLAN_TIME_MAX_STUB,
+  PLAN_TIME_MIN_STUB,
+} from 'test/api/plan/stub';
 import { USER_STUB } from 'test/api/user/stub';
 import createTestingModule from 'test/utils/create-testing-module';
 
@@ -117,6 +122,26 @@ describe('PlanService', () => {
         expect(error).toBeInstanceOf(ConflictException);
         expect(typeof error.message).toBe('string');
       }
+    });
+  });
+
+  describe('getPlans', () => {
+    it('should return plans between timemin, timemax query', async () => {
+      const args = {
+        userId: USER_STUB.id,
+        timeMin: PLAN_TIME_MIN_STUB,
+        timeMax: PLAN_TIME_MAX_STUB,
+      };
+      const result = [{ ...PLAN_STUB_WITH_COLOR }];
+      const planRepoSpy = jest
+        .spyOn(planRepository, 'findPlansBetweenDate')
+        .mockResolvedValue([{ ...PLAN_STUB }]);
+
+      const plans = await planService.getPlans(args);
+
+      expect(planRepoSpy).toHaveBeenCalledTimes(1);
+      expect(planRepoSpy).toHaveBeenCalledWith(args);
+      expect(plans).toEqual(result);
     });
   });
 });

--- a/test/api/plan/stub.ts
+++ b/test/api/plan/stub.ts
@@ -9,7 +9,7 @@ const PLAN_STUB: PlanResDto = Object.freeze({
   id: 1,
   title: 'MyPlan',
   description: '',
-  color: '#123456',
+  color: '123456',
   startTime: new Date(
     '2023-03-07 15:38:06.785155',
   ).toISOString() as unknown as Date,
@@ -24,4 +24,14 @@ const PLAN_STUB: PlanResDto = Object.freeze({
   ] as TagResDto[],
 });
 
-export { PLAN_STUB, PLAN_TIME_MIN_STUB, PLAN_TIME_MAX_STUB };
+const PLAN_STUB_WITH_COLOR: PlanResDto = Object.freeze({
+  ...PLAN_STUB,
+  color: '#123456',
+});
+
+export {
+  PLAN_STUB,
+  PLAN_STUB_WITH_COLOR,
+  PLAN_TIME_MIN_STUB,
+  PLAN_TIME_MAX_STUB,
+};

--- a/test/api/plan/stub.ts
+++ b/test/api/plan/stub.ts
@@ -1,6 +1,6 @@
 import { PlanResDto } from '@/dto/plan';
 import { TagResDto } from '@/dto/tag';
-import { PLAN_TYPE, UserEntity } from '@/entities';
+import { PLAN_TYPE } from '@/entities';
 
 const PLAN_TIME_MIN_STUB = new Date('2023-03-07 00:00:00.000000');
 const PLAN_TIME_MAX_STUB = new Date('2023-03-07 23:59:59.999999');
@@ -17,19 +17,11 @@ const PLAN_STUB: PlanResDto = Object.freeze({
   type: PLAN_TYPE.TASK,
   isAllDay: true,
 
-  createdAt: new Date(
-    '2023-03-07 15:38:06.785155',
-  ).toISOString() as unknown as Date,
-  updatedAt: new Date(
-    '2023-03-07 15:38:06.785155',
-  ).toISOString() as unknown as Date,
-
   categoryId: 1,
   tags: [
     { id: 1, name: '태그1' },
     { id: 2, name: '태그2' },
   ] as TagResDto[],
-  user: {} as UserEntity,
 });
 
 export { PLAN_STUB, PLAN_TIME_MIN_STUB, PLAN_TIME_MAX_STUB };

--- a/test/api/tag/tag.service.spec.ts
+++ b/test/api/tag/tag.service.spec.ts
@@ -194,4 +194,30 @@ describe('TagService', () => {
       expect(tag).toEqual(shouldBe);
     });
   });
+
+  describe('success delete tag that has no plan', () => {
+    it('return deleted tag info (name & id)', async () => {
+      const userId = stubTag.user.id;
+      const tagId = stubTag.id;
+      const params = { userId, tagId };
+      const shouldBe = { name: stubTag.name, id: stubTag.id };
+
+      const tagRepoFindByTagIdWithPlans = jest
+        .spyOn(tagRepo, 'findTagWithPlans')
+        .mockResolvedValue({
+          id: tagId,
+          name: stubTag.name,
+          plans: [],
+        });
+      const tagRepoDeleteTag = jest
+        .spyOn(tagRepo, 'deleteTag')
+        .mockResolvedValue(true);
+
+      const tag = await tagService.deleteTagIfNotReferenced(params);
+
+      expect(tagRepoFindByTagIdWithPlans).toHaveBeenCalledWith(params);
+      expect(tagRepoDeleteTag).toHaveBeenCalledWith(params);
+      expect(tag).toEqual(shouldBe);
+    });
+  });
 });

--- a/test/api/tag/tag.service.spec.ts
+++ b/test/api/tag/tag.service.spec.ts
@@ -243,5 +243,25 @@ describe('TagService', () => {
       expect(tagRepoDeleteTag).toHaveBeenCalledTimes(0);
       expect(tag).toEqual(shouldBe);
     });
+
+    it('return null if no tag', async () => {
+      const userId = stubTag.user.id;
+      const tagId = stubTag.id;
+      const params = { userId, tagId };
+      const shouldBe = null;
+
+      const tagRepoFindByTagIdWithPlans = jest
+        .spyOn(tagRepo, 'findTagWithPlans')
+        .mockResolvedValue(shouldBe);
+      const tagRepoDeleteTag = jest
+        .spyOn(tagRepo, 'deleteTag')
+        .mockResolvedValue(true);
+
+      const tag = await tagService.deleteTagIfNotReferenced(params);
+
+      expect(tagRepoFindByTagIdWithPlans).toHaveBeenCalledWith(params);
+      expect(tagRepoDeleteTag).toHaveBeenCalledTimes(0);
+      expect(tag).toEqual(shouldBe);
+    });
   });
 });

--- a/test/api/tag/tag.service.spec.ts
+++ b/test/api/tag/tag.service.spec.ts
@@ -219,5 +219,29 @@ describe('TagService', () => {
       expect(tagRepoDeleteTag).toHaveBeenCalledWith(params);
       expect(tag).toEqual(shouldBe);
     });
+
+    it('return tag without deleting', async () => {
+      const userId = stubTag.user.id;
+      const tagId = stubTag.id;
+      const params = { userId, tagId };
+      const shouldBe = { name: stubTag.name, id: stubTag.id };
+
+      const tagRepoFindByTagIdWithPlans = jest
+        .spyOn(tagRepo, 'findTagWithPlans')
+        .mockResolvedValue({
+          id: tagId,
+          name: stubTag.name,
+          plans: [{ id: 1 }],
+        });
+      const tagRepoDeleteTag = jest
+        .spyOn(tagRepo, 'deleteTag')
+        .mockResolvedValue(true);
+
+      const tag = await tagService.deleteTagIfNotReferenced(params);
+
+      expect(tagRepoFindByTagIdWithPlans).toHaveBeenCalledWith(params);
+      expect(tagRepoDeleteTag).toHaveBeenCalledTimes(0);
+      expect(tag).toEqual(shouldBe);
+    });
   });
 });

--- a/test/utils/omit-key.ts
+++ b/test/utils/omit-key.ts
@@ -1,4 +1,7 @@
-function omitKey(target: object, strs: string[]) {
+function omitKey<TType extends object, TKey extends keyof TType>(
+  target: TType,
+  strs: TKey[],
+): Omit<TType, TKey> {
   return strs.reduce(
     (obj, key) => {
       if (Object.hasOwnProperty.call(target, key)) {


### PR DESCRIPTION
* Closes #40 
* Closes #41 
* Closes #57 

## ✨ **구현 기능 명세**

- Category Service
    - User가 조작할 수 있는 Category인지 검사 ( checkUserOwnCategory )
    - Id에 해당하는 Category가 있는지 검사 ( checkHasCategory )
- Tag Service
    - Plan이 참조하지 않는 Tag 삭제 ( deleteTagIfNotReferenced )
- Plan Service
    - 조회 ( getPlan )
    - 추가 ( createPlan )
    - 수정 ( updatePlan )
    - 삭제 ( deletePlan )

## 🎁 **주목할 점**

* Plan Request Dto의 값이 실제로 `client`에서 사용할 때 동일하게 줄 수 있을 것인지 고민해야 합니다.
* Tag와 Category와 관련된 작업이 완료되었지만 `client`의 동작에 따라 추가적인 사항이 생길 수 있습니다.

### Plan 삭제 시 Tag

Plan이 삭제됐을 때 전체 Tag에 대해서 한번 검사합니다.
    - 태그를 참조하는 plan이 하나도 없을 경우 해당 태그도 함께 삭제합니다.

## 😭 **어려웠던 점**

### TypeORM 의 cascade true 옵션 값 이슈

이전에 `create` 및 `update` 함수를 작성할 때 `this.insert`와 `this.update`함수를 사용했습니다.
하지만 실제 e2e 테스팅을 진행해본 결과 관련된 값까지 함께 저장하기 위해선 `this.save`함수를 사용해야 함을 깨달았습니다.

### Service 로직의 분리와 함께 생겨나는 Query 요청

Plan에서 Category의 Validation 검사를 진행할 때 관련 로직은 Category Service에 있어야 한다고 생각했습니다.
이 때 Category Service 에서 작성한 Validation은 Category Service 내에서도 동일하게 사용할 수 있기 때문에 이 함수를 재사용하게 됩니다.

```ts
  @Transactional()
  async deleteCategory(
    deleteCategoryArgs: IDeleteCategoryArgs,
  ): Promise<CategoryResDto> {
    await this.checkUserOwnCategory(deleteCategoryArgs);

    const category = await this.categoryRepo.findCategoryById(
      deleteCategoryArgs,
    );

    if (!(await this.categoryRepo.deleteCategory(deleteCategoryArgs))) {
      throw new InternalServerErrorException(
        '카테고리를 삭제하던 도중 에러가 발생했습니다. \n 삭제 요청을 취소합니다.',
      );
    }
    return mapToHexColor(category);
  }
```

이때 중요한 점은 `findCategoryById`의 값이 null 인 것과 `category.user.id` 의 값으로 `checkUserOwnCategory`의 로직을 대체할 수 있고 이를 통해 select Query 요청을 한 번 아낄 수 있다는 장점이 있습니다.
다만 Service의 로직 분리가 되지 않으므로 유지보수에 안좋은 영향을 끼칠 수 있습니다.

저는 Testing 환경에서 `checkUserOwnCategory`라는 것이 제대로 동작함을 입증하여 이를 사용하는 함수에서는 관련된 Validation을 신경쓰지 않도록 하여 select 혹은 exist 의 Query 한번은 사소하다는 생각으로 유지보수가 잘 되도록 선택했습니다.


## 🌄 **스크린샷**

### Unit Test

<img src="https://user-images.githubusercontent.com/55688122/230010777-0554869c-5c8f-470a-b712-4670e40e7111.png" width="500" alt="PlanService-Test"/>

<img src="https://user-images.githubusercontent.com/55688122/230010706-4aa23979-9eb3-49a1-b62b-44c25aca1a50.png" width="500" alt="CategoryService-Test"/>

<img src="https://user-images.githubusercontent.com/55688122/230010601-ba72caf8-30cd-4455-b2ff-02023683d32d.png" width="500" alt="TagService-Test"/>

### E2E Test

* getPlans
![image](https://user-images.githubusercontent.com/55688122/230013447-b59890e8-739e-468e-be22-66d8ac162106.png)

* createPlan
![image](https://user-images.githubusercontent.com/55688122/230013572-671f470b-2a4c-4260-bfa8-d003498d0ada.png)

* updatePlan
![image](https://user-images.githubusercontent.com/55688122/230013696-07ade5b8-0d14-40c3-89b2-d1b14bb35364.png)

* deletePlan
![image](https://user-images.githubusercontent.com/55688122/230013791-8e970a2a-03f9-447e-a0f0-004be97b188f.png)
