### PR TITLE
Cookie 버그 수정 및 JWT Token 인증 방식 통일

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cls-hooked": "^4.2.2",
+        "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
         "mysql2": "^3.1.2",
         "passport": "^0.6.0",
@@ -37,6 +38,7 @@
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^9.3.9",
         "@types/cls-hooked": "^4.3.3",
+        "@types/cookie-parser": "^1.4.3",
         "@types/express": "^4.17.13",
         "@types/jest": "29.2.4",
         "@types/node": "18.11.18",
@@ -2074,6 +2076,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -3746,6 +3757,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11879,6 +11910,15 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -13172,6 +13212,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cls-hooked": "^4.2.2",
+    "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
     "mysql2": "^3.1.2",
     "passport": "^0.6.0",
@@ -48,6 +49,7 @@
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^9.3.9",
     "@types/cls-hooked": "^4.3.3",
+    "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.13",
     "@types/jest": "29.2.4",
     "@types/node": "18.11.18",
@@ -93,6 +95,8 @@
       "^@/(.*)$": "<rootDir>/src/$1",
       "^test/(.*)$": "<rootDir>/test/$1"
     },
-    "setupFilesAfterEnv": ["./jest.setup.ts"]
+    "setupFilesAfterEnv": [
+      "./jest.setup.ts"
+    ]
   }
 }

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -40,14 +40,20 @@ export class AuthService {
   registerTokenInCookie({ type, token, res }: IRegisterTokenInCookieArgs) {
     const { ACCESS_HEADER, REFRESH_HEADER, COOKIE_MAX_AGE } = this.env;
 
-    const tokenName =
-      type === EJwtTokenType.ACCESS ? ACCESS_HEADER : REFRESH_HEADER;
+    const isRefresh = type === EJwtTokenType.REFRESH;
+    const tokenName = isRefresh ? REFRESH_HEADER : ACCESS_HEADER;
 
-    const cookieOptions: CookieOptions = {
+    let cookieOptions: CookieOptions = {
       maxAge: Number(COOKIE_MAX_AGE),
-      httpOnly: true,
       secure: true,
     };
+
+    if (isRefresh) {
+      cookieOptions = {
+        ...cookieOptions,
+        httpOnly: true,
+      };
+    }
 
     res.cookie(tokenName, token, cookieOptions);
   }

--- a/src/common/strategies/jwt-auth.strategy.ts
+++ b/src/common/strategies/jwt-auth.strategy.ts
@@ -9,7 +9,17 @@ import { TTokenUser } from '@/types';
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private readonly configService: ConfigService) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => {
+          const refreshHeader = this.configService.get('REFRESH_HEADER');
+          const refreshCookie = request.cookies?.[refreshHeader];
+
+          const { authorization } = request.headers;
+          const accessToken = /^Bearer (.*)$/.exec(authorization)?.[1];
+
+          return accessToken ?? refreshCookie ?? null;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: configService.get('JWT_SECRET_KEY'),
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import * as cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { HttpExceptionFilter } from '@/common/filters';
@@ -39,6 +40,7 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalInterceptors(new SuccessInterceptor());
   app.setGlobalPrefix('api');
+  app.use(cookieParser());
 
   const configService = app.get(ConfigService);
   const PORT = configService.get('PORT');


### PR DESCRIPTION
* Closes #59 

## ✨ **구현 기능 명세**

- [x] cookie-parser 설치 및 적용
- [x] Access Token을 Bearer로 받기
- [x] Refresh Token을 httponly 값으로 받기

## 🎁 **주목할 점**

서버에서는 다음과 같은 로직으로 Token을 읽고 판단합니다.
1. headers에 `authorization` 속성 값으로 값이 있는지? (있다면 Access Token으로 인식, with Bearer)
2. Cookie 값에 Refresh Token 값이 있는지? (있다면 Refresh Token으로 인식)

## 😭 **어려웠던 점**

함께 Access, Refresh Token 개념 정의를 확실히 하는 것과 오류 찾는 과정이 어려웠네요!
