### PR TITLE
월 단위로 일정을 가져올 수 있도록 설정 / Date 기준을 UTC로 설정

### DIFF
--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -25,12 +25,37 @@ import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
 import { PlanCreateReqDto, PlanResDto, PlanUpdateReqDto } from '@/dto/plan';
 import { TTokenUser } from '@/types';
+import { getBetweenDate } from '@/utils/getBetweenDate';
 
 import { PlanService } from './plan.service';
 
 @Controller('plan')
 export class PlanController {
   constructor(private readonly planService: PlanService) {}
+
+  @ApiOperation({
+    summary: '원하는 달의 일정 조회',
+  })
+  @ApiQuery({
+    name: 'date',
+    type: Date,
+    example: '2023-04-01T00:00:00.000Z',
+    required: true,
+  })
+  @ApiOkResponse({
+    description: '일정 조회 성공',
+    type: PlanResDto,
+    isArray: true,
+  })
+  @Get('/')
+  async getPlans(
+    @Query('date', ParseDatePipe) date: Date,
+    @User() user: TTokenUser,
+  ) {
+    const [timeMin, timeMax] = getBetweenDate(date);
+
+    return this.planService.getPlans({ timeMin, timeMax, userId: user.id });
+  }
 
   @ApiOperation({
     summary: '원하는 날짜 사이의 일정 조회',

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
+  ApiTags,
 } from '@nestjs/swagger';
 
 import { User } from '@/common/decorators/user.decorator';
@@ -29,6 +30,7 @@ import { getBetweenDate } from '@/utils/getBetweenDate';
 
 import { PlanService } from './plan.service';
 
+@ApiTags('plan')
 @Controller('plan')
 export class PlanController {
   constructor(private readonly planService: PlanService) {}

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -39,7 +39,7 @@ export class PlanController {
   @ApiQuery({
     name: 'date',
     type: Date,
-    example: '2023-04-01T00:00:00.000Z',
+    example: '2023-04',
     required: true,
   })
   @ApiOkResponse({
@@ -54,7 +54,13 @@ export class PlanController {
   ) {
     const [timeMin, timeMax] = getBetweenDate(date);
 
-    return this.planService.getPlans({ timeMin, timeMax, userId: user.id });
+    const data = await this.planService.getPlans({
+      timeMin,
+      timeMax,
+      userId: user.id,
+    });
+
+    return data;
   }
 
   @ApiOperation({

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -33,7 +33,7 @@ export class PlanController {
   constructor(private readonly planService: PlanService) {}
 
   @ApiOperation({
-    summary: '원하는 날짜의 일정 조회',
+    summary: '원하는 날짜 사이의 일정 조회',
   })
   @ApiQuery({
     name: 'timemin',
@@ -55,8 +55,8 @@ export class PlanController {
   @ApiBadRequestResponse({
     description: 'timemin query 값이 timemax query 값보다 이후일 때',
   })
-  @Get('/')
-  async getPlans(
+  @Get('/between')
+  async getBetweenPlans(
     @Query('timemin', ParseDatePipe) timeMin: Date,
     @Query('timemax', ParseDatePipe) timeMax: Date,
     @User() user: TTokenUser,

--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -1,4 +1,4 @@
-import { Between, Repository } from 'typeorm';
+import { Between, LessThan, MoreThan, Repository } from 'typeorm';
 
 import { CustomRepository } from '@/common/decorators';
 import { PlanResDto } from '@/dto/plan';
@@ -31,9 +31,18 @@ export class PlanRepository extends Repository<PlanEntity> {
     timeMax,
   }: IGetPlansArgs): Promise<PlanResDto[]> {
     return await this.find({
-      where: {
-        startTime: Between(timeMin, timeMax),
-      },
+      where: [
+        {
+          startTime: Between(timeMin, timeMax),
+        },
+        {
+          endTime: Between(timeMin, timeMax),
+        },
+        {
+          startTime: LessThan(timeMin),
+          endTime: MoreThan(timeMax),
+        },
+      ],
       select: PLAN_SELECT,
       relations: { tags: true },
     });

--- a/src/entities/plan.entity.ts
+++ b/src/entities/plan.entity.ts
@@ -81,7 +81,7 @@ export class PlanEntity extends DefaultEntity {
   type!: PLAN_TYPE;
 
   @ApiProperty({
-    example: '2023-04-05T04:41:19.933Z',
+    example: '2023-04-01T00:00:00.000Z',
   })
   @Column({ type: 'datetime' })
   @IsNotEmpty()
@@ -90,7 +90,7 @@ export class PlanEntity extends DefaultEntity {
   startTime!: Date;
 
   @ApiProperty({
-    example: '2023-04-05T04:41:19.933Z',
+    example: '2023-04-30T00:00:00.000Z',
   })
   @Column({ type: 'datetime', nullable: true })
   @IsOptional()

--- a/src/utils/getBetweenDate.ts
+++ b/src/utils/getBetweenDate.ts
@@ -1,0 +1,18 @@
+const getBetweenDate = (date: Date) => {
+  const fullYear = date.getFullYear();
+  const month = date.getMonth() + 1;
+
+  let nextMonth = month + 1;
+  const additionYear = nextMonth > 12 ? 1 : 0;
+  const nextFullYear = fullYear + additionYear;
+  nextMonth = nextMonth > 12 ? nextMonth - 12 : nextMonth;
+
+  const firstOfMonth = new Date(`${fullYear}-${month}-01, 00:00:00`);
+  const firstOfNextMonth = new Date(
+    `${nextFullYear}-${nextMonth}-01, 00:00:00`,
+  );
+
+  return [firstOfMonth, firstOfNextMonth];
+};
+
+export { getBetweenDate };

--- a/src/utils/getBetweenDate.ts
+++ b/src/utils/getBetweenDate.ts
@@ -7,12 +7,16 @@ const getBetweenDate = (date: Date) => {
   const nextFullYear = fullYear + additionYear;
   nextMonth = nextMonth > 12 ? nextMonth - 12 : nextMonth;
 
-  const firstOfMonth = new Date(`${fullYear}-${month}-01, 00:00:00`);
-  const firstOfNextMonth = new Date(
-    `${nextFullYear}-${nextMonth}-01, 00:00:00`,
+  const firstOfMonth = new Date(
+    `${fullYear}-${month.toString().padStart(2, '0')}-01T00:00:00.000Z`,
+  );
+  const lastOfMonth = new Date(
+    new Date(
+      `${nextFullYear}-${nextMonth.toString().padStart(2, '0')}-01T00:00:00Z`,
+    ).getTime() - 1,
   );
 
-  return [firstOfMonth, firstOfNextMonth];
+  return [firstOfMonth, lastOfMonth];
 };
 
 export { getBetweenDate };

--- a/src/utils/getBetweenDate.ts
+++ b/src/utils/getBetweenDate.ts
@@ -12,7 +12,9 @@ const getBetweenDate = (date: Date) => {
   );
   const lastOfMonth = new Date(
     new Date(
-      `${nextFullYear}-${nextMonth.toString().padStart(2, '0')}-01T00:00:00Z`,
+      `${nextFullYear}-${nextMonth
+        .toString()
+        .padStart(2, '0')}-01T00:00:00.000Z`,
     ).getTime() - 1,
   );
 

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -40,7 +40,7 @@ describe('PlanController', () => {
     expect(planService).toBeDefined();
   });
 
-  describe('GET /plan', () => {
+  describe('GET /plan/between', () => {
     it('expect success response - plans (Query with between time)', async () => {
       const timeMin = PLAN_TIME_MIN_STUB;
       const timeMax = PLAN_TIME_MAX_STUB;
@@ -54,7 +54,7 @@ describe('PlanController', () => {
       };
 
       const request = await testRequest(app.getHttpServer())
-        .get(`/plan`)
+        .get(`/plan/between`)
         .query({ timemin: timeMin, timemax: timeMax })
         .expect(200);
 
@@ -84,7 +84,7 @@ describe('PlanController', () => {
       };
 
       const request = await testRequest(app.getHttpServer())
-        .get(`/plan`)
+        .get(`/plan/between`)
         .query({ timemin: timeMax, timemax: timeMin })
         .expect(400);
 
@@ -111,7 +111,7 @@ describe('PlanController', () => {
       };
 
       const request = await testRequest(app.getHttpServer())
-        .get(`/plan`)
+        .get(`/plan/between`)
         .query({})
         .expect(400);
 

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -45,6 +45,7 @@ describe('PlanController', () => {
     it('expect success response - plans', async () => {
       const date = new Date();
       const [timeMin, timeMax] = getBetweenDate(date);
+      console.log(timeMin, timeMax);
 
       const plans = [{ ...PLAN_STUB }];
       const planServSpy = jest
@@ -57,7 +58,7 @@ describe('PlanController', () => {
 
       const request = await testRequest(app.getHttpServer())
         .get(`/plan`)
-        .query({ date: timeMin })
+        .query({ date })
         .expect(200);
 
       expect(planServSpy).toHaveBeenCalledWith({

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -9,6 +9,7 @@ import { PlanController } from '@/api/plan/plan.controller';
 import { PlanService } from '@/api/plan/plan.service';
 import { HttpExceptionFilter } from '@/common/filters';
 import { SuccessInterceptor } from '@/common/interceptors';
+import { getBetweenDate } from '@/utils/getBetweenDate';
 import createTestingModule from 'test/utils/create-testing-module';
 import { omitKey } from 'test/utils/omit-key';
 
@@ -38,6 +39,61 @@ describe('PlanController', () => {
 
   it('Check defining Modules', () => {
     expect(planService).toBeDefined();
+  });
+
+  describe('GET /plan', () => {
+    it('expect success response - plans', async () => {
+      const date = new Date();
+      const [timeMin, timeMax] = getBetweenDate(date);
+
+      const plans = [{ ...PLAN_STUB }];
+      const planServSpy = jest
+        .spyOn(planService, 'getPlans')
+        .mockResolvedValue(plans);
+      const result = {
+        success: true,
+        data: plans,
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .get(`/plan`)
+        .query({ date: timeMin })
+        .expect(200);
+
+      expect(planServSpy).toHaveBeenCalledWith({
+        timeMin,
+        timeMax,
+        userId: USER_STUB.id,
+      });
+      expect(request.body).toEqual(result);
+    });
+
+    it('expect failure response with invalid date query (Empty)', async () => {
+      const planServSpy = jest
+        .spyOn(planService, 'getPlans')
+        .mockRejectedValue(
+          new InternalServerErrorException(
+            'Service의 getPlans가 실행되어선 안됩니다.',
+          ),
+        );
+      const result = {
+        error: 'Bad Request',
+        statusCode: 400,
+        success: false,
+        message: 'Validation failed (Date string is expected)',
+      };
+
+      const request = await testRequest(app.getHttpServer())
+        .get(`/plan`)
+        .query({})
+        .expect(400);
+
+      expect(planServSpy).toHaveBeenCalledTimes(0);
+      expect(request.body).toEqual({
+        ...result,
+        timestamp: request.body.timestamp,
+      });
+    });
   });
 
   describe('GET /plan/between', () => {

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -45,7 +45,6 @@ describe('PlanController', () => {
     it('expect success response - plans', async () => {
       const date = new Date();
       const [timeMin, timeMax] = getBetweenDate(date);
-      console.log(timeMin, timeMax);
 
       const plans = [{ ...PLAN_STUB }];
       const planServSpy = jest

--- a/test/api/plan/stub.ts
+++ b/test/api/plan/stub.ts
@@ -2,8 +2,8 @@ import { PlanResDto } from '@/dto/plan';
 import { TagResDto } from '@/dto/tag';
 import { PLAN_TYPE } from '@/entities';
 
-const PLAN_TIME_MIN_STUB = new Date('2023-03-07 00:00:00.000000');
-const PLAN_TIME_MAX_STUB = new Date('2023-03-07 23:59:59.999999');
+const PLAN_TIME_MIN_STUB = new Date('2023-03-07T00:00:00.000000Z');
+const PLAN_TIME_MAX_STUB = new Date('2023-03-07T23:59:59.999999Z');
 
 const PLAN_STUB: PlanResDto = Object.freeze({
   id: 1,
@@ -11,8 +11,8 @@ const PLAN_STUB: PlanResDto = Object.freeze({
   description: '',
   color: '123456',
   startTime: new Date(
-    '2023-03-07 15:38:06.785155',
-  ).toISOString() as unknown as Date,
+    '2023-03-07T15:38:06.785155Z',
+  ).toUTCString() as unknown as Date,
   endTime: null,
   type: PLAN_TYPE.TASK,
   isAllDay: true,


### PR DESCRIPTION
* Closes #61

## ✨ **구현 기능 명세**

- 월 단위 데이터를 제대로 가져오도록 TypeORM 수정
- Query에 년, 월만 보내면 해당 달의 데이터를 가져올 수 있도록 수정
     - Test
     - Controller
- StartTime, EndTime의 기준을 UTC로 설정

## 🎁 **주목할 점**

- `/plan` 으로 API를 보낼 때 date query

`/plan?date=2023-01` 과 같이 JS의 Date 객체에 들어갔을 때 알맞은 정보이면 모두 가능합니다.
이를 통해 달의 첫 번째 날의 0시 0분, 달의 마지막 날의 23시 59분 사이의 시간을 가져오도록 수정했습니다.

- TypeORM에서 시간 비교 로직

저장되는 시간은 다음과 같은 경우의 수가 있습니다.

![image](https://user-images.githubusercontent.com/55688122/232968453-ffcfbcd5-6461-425c-b5b4-2f641a987112.png)

기존에는 StartTime이 해당 달 안에 있을 때만 불러왔었습니다.
이에 해당하는 일정을 모두 불러올수 있도록 버그를 수정했습니다.

## 😭 **어려웠던 점**

Swagger로 테스팅하던 도중 클라이언트에서 보낸 `Date`와 백엔드에서 처리하는 `Date`의 기준이 다를 수 있다는 것을 깨달았습니다.

이는 치명적인 에러를 유발할 수 있습니다.
- 유저가 한국 시간을 중심으로 한 컴퓨터를 사용하다가 다른 시간을 중심으로 한 컴퓨터를 이용하게 됐을 때
- 년, 월 만을 기준으로 해당 달의 데이터를 가져올 때 비교 로직의 중심을 작성할 수 없음
- 알림 설정을 했을 때 어떤 시간을 기준으로 알려줄 지 서버가 확언할 수 없음

해당 사항을 팀원과 함께 논의한 결과 다음과 같이 정했습니다.

1. 서버에서 저장하는 `startTime`, `endTime`은 UTC를 기준으로 저장한다.
2. 서버로 보내는 API 데이터는 모두 UTC로 저장할 수 있도록 한다.
3. 클라이언트에서는 받은 `Date`가 UTC임을 인지하고 이를 가공할 수 있도록 한다.

## 🌄 **스크린샷**

![image](https://user-images.githubusercontent.com/55688122/232966679-eb88f693-cf23-4fc4-9e35-eb77d7fd657c.png)
