### PR TITLE
applyDecorator를 통한 Swagger Decorator 분리

### DIFF
--- a/src/api/category/category.controller.ts
+++ b/src/api/category/category.controller.ts
@@ -9,22 +9,17 @@ import {
   Put,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import {
-  ApiConflictResponse,
-  ApiCreatedResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-  ApiUnprocessableEntityResponse,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { CategoryService } from '@/api/category/category.service';
 import { User } from '@/common/decorators';
 import {
-  CategoryCreateReqDto,
-  CategoryUpdateReqDto,
-  CategoryResDto,
-} from '@/dto/category';
+  CreateCategorySwagger,
+  DeleteCategorySwagger,
+  ReadCategorySwagger,
+  UpdateCategorySwagger,
+} from '@/common/decorators/swagger/swagger-category.decorator';
+import { CategoryCreateReqDto, CategoryUpdateReqDto } from '@/dto/category';
 import { UserEntity } from '@/entities';
 
 @ApiTags('category')
@@ -32,29 +27,13 @@ import { UserEntity } from '@/entities';
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
 
-  @ApiOperation({
-    summary: '카테고리 조회',
-  })
-  @ApiOkResponse({
-    description: '카테고리 조회 성공',
-    type: CategoryResDto,
-    isArray: true,
-  })
+  @ReadCategorySwagger()
   @Get()
   async readCategory(@User() user: UserEntity) {
     return this.categoryService.readCategory(user.id);
   }
 
-  @ApiOperation({
-    summary: '카테고리 생성',
-  })
-  @ApiCreatedResponse({
-    description: '카테고리 생성 성공',
-    type: CategoryResDto,
-  })
-  @ApiConflictResponse({
-    description: '이미 카테고리가 존재함',
-  })
+  @CreateCategorySwagger()
   @Post()
   async createCategory(
     @Body() { name: categoryName, color }: CategoryCreateReqDto,
@@ -67,20 +46,7 @@ export class CategoryController {
     });
   }
 
-  @ApiOperation({
-    summary: '카테고리 수정',
-  })
-  @ApiOkResponse({
-    description: '카테고리 수정 성공',
-    type: CategoryResDto,
-  })
-  @ApiConflictResponse({
-    description:
-      '카테고리가 존재하지 않거나 동일한 이름으로 수정하려고 하는 경우',
-  })
-  @ApiUnprocessableEntityResponse({
-    description: 'Request Body에 name, color가 모두 없는 경우',
-  })
+  @UpdateCategorySwagger()
   @Put(':categoryId')
   async updateCategory(
     @Param('categoryId', ParseIntPipe) categoryId: number,
@@ -98,16 +64,7 @@ export class CategoryController {
     });
   }
 
-  @ApiOperation({
-    summary: '카테고리 삭제',
-  })
-  @ApiOkResponse({
-    description: '카테고리 삭제 성공',
-    type: CategoryResDto,
-  })
-  @ApiConflictResponse({
-    description: '카테고리가 존재하지 않는 경우',
-  })
+  @DeleteCategorySwagger()
   @Delete(':categoryId')
   async deleteCategory(
     @Param('categoryId', ParseIntPipe) categoryId: number,

--- a/src/api/plan/plan.controller.ts
+++ b/src/api/plan/plan.controller.ts
@@ -10,21 +10,18 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
-import {
-  ApiBadRequestResponse,
-  ApiConflictResponse,
-  ApiCreatedResponse,
-  ApiForbiddenResponse,
-  ApiInternalServerErrorResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiQuery,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
+import {
+  CreatePlanSwagger,
+  DeletePlanSwagger,
+  GetBetweenPlansSwagger,
+  GetPlansSwagger,
+  UpdatePlanSwagger,
+} from '@/common/decorators/swagger/swagger-plan.decorator';
 import { User } from '@/common/decorators/user.decorator';
 import { ParseDatePipe } from '@/common/pipes';
-import { PlanCreateReqDto, PlanResDto, PlanUpdateReqDto } from '@/dto/plan';
+import { PlanCreateReqDto, PlanUpdateReqDto } from '@/dto/plan';
 import { TTokenUser } from '@/types';
 import {
   getStartTimeDate,
@@ -39,20 +36,7 @@ import { PlanService } from './plan.service';
 export class PlanController {
   constructor(private readonly planService: PlanService) {}
 
-  @ApiOperation({
-    summary: '원하는 달의 일정 조회',
-  })
-  @ApiQuery({
-    name: 'date',
-    type: Date,
-    example: '2023-04',
-    required: true,
-  })
-  @ApiOkResponse({
-    description: '일정 조회 성공',
-    type: PlanResDto,
-    isArray: true,
-  })
+  @GetPlansSwagger()
   @Get('/')
   async getPlans(
     @Query('date', ParseDatePipe) date: Date,
@@ -69,29 +53,7 @@ export class PlanController {
     return data;
   }
 
-  @ApiOperation({
-    summary: '원하는 날짜 사이의 일정 조회',
-  })
-  @ApiQuery({
-    name: 'timemin',
-    type: Date,
-    example: '2023-04-01T00:00:00.000Z',
-    required: true,
-  })
-  @ApiQuery({
-    name: 'timemax',
-    type: Date,
-    example: '2023-05-01T00:00:00.000Z',
-    required: true,
-  })
-  @ApiOkResponse({
-    description: '일정 조회 성공',
-    type: PlanResDto,
-    isArray: true,
-  })
-  @ApiBadRequestResponse({
-    description: 'timemin query 값이 timemax query 값보다 이후일 때',
-  })
+  @GetBetweenPlansSwagger()
   @Get('/between')
   async getBetweenPlans(
     @Query('timemin', ParseDatePipe) timeMin: Date,
@@ -111,16 +73,7 @@ export class PlanController {
     });
   }
 
-  @ApiOperation({
-    summary: '새로운 일정 추가',
-  })
-  @ApiCreatedResponse({
-    description: '일정 생성 성공',
-    type: PlanResDto,
-  })
-  @ApiConflictResponse({
-    description: '연결하고자 하는 카테고리 아이디가 존재하지 않는 경우',
-  })
+  @CreatePlanSwagger()
   @Post('/')
   async createPlan(
     @Body() createPlanReqDto: PlanCreateReqDto,
@@ -132,23 +85,7 @@ export class PlanController {
     });
   }
 
-  @ApiOperation({
-    summary: '일정 수정',
-  })
-  @ApiOkResponse({
-    description: '일정 수정 성공',
-    type: PlanResDto,
-  })
-  @ApiBadRequestResponse({
-    description: '바꾸려는 일정 값이(Body 혹은 planId 값) 존재하지 않을 때',
-  })
-  @ApiConflictResponse({
-    description:
-      '일정 아이디가 존재하지 않거나 카테고리 아이디가 존재하지 않는 경우',
-  })
-  @ApiForbiddenResponse({
-    description: '일정 혹은 카테고리가 유저가 소유한 것이 아닐 경우',
-  })
+  @UpdatePlanSwagger()
   @Put('/:planId')
   async updatePlan(
     @Param('planId', ParseIntPipe) planId: number,
@@ -167,22 +104,7 @@ export class PlanController {
     });
   }
 
-  @ApiOperation({
-    summary: '일정 삭제',
-  })
-  @ApiOkResponse({
-    description: '일정 삭제 성공',
-    type: PlanResDto,
-  })
-  @ApiConflictResponse({
-    description: '일정 아이디가 존재하지 않을 경우',
-  })
-  @ApiForbiddenResponse({
-    description: '일정이 유저가 소유한 것이 아닐 경우',
-  })
-  @ApiInternalServerErrorResponse({
-    description: '일정 삭제가 데이터베이스 오류로 실패된 경우',
-  })
+  @DeletePlanSwagger()
   @Delete('/:planId')
   async deletePlan(
     @Param('planId', ParseIntPipe) planId: number,

--- a/src/api/tag/tag.controller.ts
+++ b/src/api/tag/tag.controller.ts
@@ -8,17 +8,16 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
-import {
-  ApiConflictResponse,
-  ApiCreatedResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { TagService } from '@/api/tag/tag.service';
 import { User } from '@/common/decorators';
-import { TagReqDto, TagResDto } from '@/dto/tag';
+import {
+  CreateTagSwagger,
+  DeleteTagSwagger,
+  UpdateTagSwagger,
+} from '@/common/decorators/swagger/swagger-tag.decorator';
+import { TagReqDto } from '@/dto/tag';
 import { UserEntity } from '@/entities';
 
 @ApiTags('tag')
@@ -26,16 +25,7 @@ import { UserEntity } from '@/entities';
 export class TagController {
   constructor(private readonly tagService: TagService) {}
 
-  @ApiOperation({
-    summary: '태그 생성',
-  })
-  @ApiCreatedResponse({
-    description: '태그 생성 성공',
-    type: TagResDto,
-  })
-  @ApiConflictResponse({
-    description: '이미 태그가 존재함',
-  })
+  @CreateTagSwagger()
   @Post()
   @HttpCode(201)
   async createTag(
@@ -45,16 +35,7 @@ export class TagController {
     return this.tagService.createTag({ userId: user.id, tagName });
   }
 
-  @ApiOperation({
-    summary: '태그 수정',
-  })
-  @ApiOkResponse({
-    description: '태그 수정 성공',
-    type: () => TagResDto,
-  })
-  @ApiConflictResponse({
-    description: '태그가 존재하지 않거나 동일한 이름으로 수정하려고 하는 경우',
-  })
+  @UpdateTagSwagger()
   @Put(':tagId')
   async updateTag(
     @Param('tagId', ParseIntPipe) tagId: number,
@@ -64,13 +45,7 @@ export class TagController {
     return this.tagService.updateTag({ userId: user.id, tagId, tagName });
   }
 
-  @ApiOperation({
-    summary: '태그 삭제',
-  })
-  @ApiOkResponse({
-    description: '태그 삭제 결과 (true: 삭제 성공 / false: 존재하지 않는 태그)',
-    type: () => true,
-  })
+  @DeleteTagSwagger()
   @Delete(':tagId')
   async deleteTag(
     @Param('tagId', ParseIntPipe) tagId: number,

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -1,30 +1,17 @@
 import { Controller, Get } from '@nestjs/common';
-import {
-  ApiInternalServerErrorResponse,
-  ApiNotFoundResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { UserService } from '@/api/user/user.service';
 import { User } from '@/common/decorators';
-import { UserEntity } from '@/entities';
+import { GetUserSwagger } from '@/common/decorators/swagger/swagger-user.decorator';
 import { TTokenUser } from '@/types';
 
+@ApiTags('user')
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @ApiInternalServerErrorResponse({
-    description: '데이터 베이스에서 제대로 값을 읽어오지 못한 경우',
-  })
-  @ApiUnauthorizedResponse({
-    description: 'access된 유저가 인증되지 않은 유저일 경우',
-  })
-  @ApiNotFoundResponse({ description: '유저 정보가 존재하지 않을경우' })
-  @ApiOkResponse({ type: UserEntity })
-  @ApiOperation({ summary: '유저 정보 가져오기' })
+  @GetUserSwagger()
   @Get()
   async getUser(@User() user: TTokenUser) {
     return this.userService.getUser(user.id);

--- a/src/common/decorators/swagger/swagger-category.decorator.ts
+++ b/src/common/decorators/swagger/swagger-category.decorator.ts
@@ -1,0 +1,79 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnprocessableEntityResponse,
+} from '@nestjs/swagger';
+
+import { CategoryResDto } from '@/dto/category';
+
+const ReadCategorySwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '카테고리 조회',
+    }),
+    ApiOkResponse({
+      description: '카테고리 조회 성공',
+      type: CategoryResDto,
+      isArray: true,
+    }),
+  );
+};
+
+const CreateCategorySwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '카테고리 생성',
+    }),
+    ApiCreatedResponse({
+      description: '카테고리 생성 성공',
+      type: CategoryResDto,
+    }),
+    ApiConflictResponse({
+      description: '이미 카테고리가 존재함',
+    }),
+  );
+};
+
+const UpdateCategorySwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '카테고리 수정',
+    }),
+    ApiOkResponse({
+      description: '카테고리 수정 성공',
+      type: CategoryResDto,
+    }),
+    ApiConflictResponse({
+      description:
+        '카테고리가 존재하지 않거나 동일한 이름으로 수정하려고 하는 경우',
+    }),
+    ApiUnprocessableEntityResponse({
+      description: 'Request Body에 name, color가 모두 없는 경우',
+    }),
+  );
+};
+
+const DeleteCategorySwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '카테고리 삭제',
+    }),
+    ApiOkResponse({
+      description: '카테고리 삭제 성공',
+      type: CategoryResDto,
+    }),
+    ApiConflictResponse({
+      description: '카테고리가 존재하지 않는 경우',
+    }),
+  );
+};
+
+export {
+  ReadCategorySwagger,
+  CreateCategorySwagger,
+  UpdateCategorySwagger,
+  DeleteCategorySwagger,
+};

--- a/src/common/decorators/swagger/swagger-plan.decorator.ts
+++ b/src/common/decorators/swagger/swagger-plan.decorator.ts
@@ -1,0 +1,126 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+} from '@nestjs/swagger';
+
+import { PlanResDto } from '@/dto/plan';
+
+const GetPlansSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '원하는 달의 일정 조회',
+    }),
+    ApiQuery({
+      name: 'date',
+      type: Date,
+      example: '2023-04',
+      required: true,
+    }),
+    ApiOkResponse({
+      description: '일정 조회 성공',
+      type: PlanResDto,
+      isArray: true,
+    }),
+  );
+};
+
+const GetBetweenPlansSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '원하는 날짜 사이의 일정 조회',
+    }),
+    ApiQuery({
+      name: 'timemin',
+      type: Date,
+      example: '2023-04-01T00:00:00.000Z',
+      required: true,
+    }),
+    ApiQuery({
+      name: 'timemax',
+      type: Date,
+      example: '2023-05-01T00:00:00.000Z',
+      required: true,
+    }),
+    ApiOkResponse({
+      description: '일정 조회 성공',
+      type: PlanResDto,
+      isArray: true,
+    }),
+    ApiBadRequestResponse({
+      description: 'timemin query 값이 timemax query 값보다 이후일 때',
+    }),
+  );
+};
+
+const CreatePlanSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '새로운 일정 추가',
+    }),
+    ApiCreatedResponse({
+      description: '일정 생성 성공',
+      type: PlanResDto,
+    }),
+    ApiConflictResponse({
+      description: '연결하고자 하는 카테고리 아이디가 존재하지 않는 경우',
+    }),
+  );
+};
+
+const UpdatePlanSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '일정 수정',
+    }),
+    ApiOkResponse({
+      description: '일정 수정 성공',
+      type: PlanResDto,
+    }),
+    ApiBadRequestResponse({
+      description: '바꾸려는 일정 값이(Body 혹은 planId 값) 존재하지 않을 때',
+    }),
+    ApiConflictResponse({
+      description:
+        '일정 아이디가 존재하지 않거나 카테고리 아이디가 존재하지 않는 경우',
+    }),
+    ApiForbiddenResponse({
+      description: '일정 혹은 카테고리가 유저가 소유한 것이 아닐 경우',
+    }),
+  );
+};
+
+const DeletePlanSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '일정 삭제',
+    }),
+    ApiOkResponse({
+      description: '일정 삭제 성공',
+      type: PlanResDto,
+    }),
+    ApiConflictResponse({
+      description: '일정 아이디가 존재하지 않을 경우',
+    }),
+    ApiForbiddenResponse({
+      description: '일정이 유저가 소유한 것이 아닐 경우',
+    }),
+    ApiInternalServerErrorResponse({
+      description: '일정 삭제가 데이터베이스 오류로 실패된 경우',
+    }),
+  );
+};
+
+export {
+  GetPlansSwagger,
+  GetBetweenPlansSwagger,
+  CreatePlanSwagger,
+  UpdatePlanSwagger,
+  DeletePlanSwagger,
+};

--- a/src/common/decorators/swagger/swagger-tag.decorator.ts
+++ b/src/common/decorators/swagger/swagger-tag.decorator.ts
@@ -1,0 +1,55 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+
+import { TagResDto } from '@/dto/tag';
+
+const CreateTagSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '태그 생성',
+    }),
+    ApiCreatedResponse({
+      description: '태그 생성 성공',
+      type: TagResDto,
+    }),
+    ApiConflictResponse({
+      description: '이미 태그가 존재함',
+    }),
+  );
+};
+
+const UpdateTagSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '태그 수정',
+    }),
+    ApiOkResponse({
+      description: '태그 수정 성공',
+      type: () => TagResDto,
+    }),
+    ApiConflictResponse({
+      description:
+        '태그가 존재하지 않거나 동일한 이름으로 수정하려고 하는 경우',
+    }),
+  );
+};
+
+const DeleteTagSwagger = () => {
+  return applyDecorators(
+    ApiOperation({
+      summary: '태그 삭제',
+    }),
+    ApiOkResponse({
+      description:
+        '태그 삭제 결과 (true: 삭제 성공 / false: 존재하지 않는 태그)',
+      type: () => true,
+    }),
+  );
+};
+
+export { CreateTagSwagger, UpdateTagSwagger, DeleteTagSwagger };

--- a/src/common/decorators/swagger/swagger-user.decorator.ts
+++ b/src/common/decorators/swagger/swagger-user.decorator.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+import { UserEntity } from '@/entities';
+
+const GetUserSwagger = () => {
+  return applyDecorators(
+    ApiInternalServerErrorResponse({
+      description: '데이터 베이스에서 제대로 값을 읽어오지 못한 경우',
+    }),
+    ApiUnauthorizedResponse({
+      description: 'access된 유저가 인증되지 않은 유저일 경우',
+    }),
+    ApiNotFoundResponse({ description: '유저 정보가 존재하지 않을경우' }),
+    ApiOkResponse({ type: UserEntity }),
+    ApiOperation({ summary: '유저 정보 가져오기' }),
+  );
+};
+
+export { GetUserSwagger };

--- a/src/common/strategies/oauth.strategy.ts
+++ b/src/common/strategies/oauth.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy, Type } from '@nestjs/passport';
 import { Strategy } from 'passport';
@@ -58,7 +58,7 @@ const getProfileByProvider = (profile: GProfile | KProfile): UserCreateDto => {
         ),
       };
     default:
-      throw new InternalServerErrorException('유저 정보가 존재하지 않습니다.');
+      throw new NotFoundException('유저 정보가 존재하지 않습니다.');
   }
 };
 


### PR DESCRIPTION
* Closes #65

## ✨ **구현 기능 명세**
- applyDecorator통해 applyDecorator를 통한 Swagger Decorator를 분리합니다.

## 🎁 **주목할 점**

```ts
const GetPlansSwagger = () => {
  return applyDecorators(
    ApiOperation({
      summary: '원하는 달의 일정 조회',
    }),
    ApiQuery({
      name: 'date',
      type: Date,
      example: '2023-04',
      required: true,
    }),
    ApiOkResponse({
      description: '일정 조회 성공',
      type: PlanResDto,
      isArray: true,
    }),
  );
};

// @/api/plan/plan.controller.ts
export class PlanController {
  @GetPlansSwagger()
  @Get('/')
  async getPlans(){
    ...
   }
}

```


## 😭 **어려웠던 점**

## 🌄 **스크린샷**