### PR TITLE
카테고리 수정 api 버그 해결

### DIFF
--- a/src/api/category/category.service.ts
+++ b/src/api/category/category.service.ts
@@ -69,23 +69,13 @@ export class CategoryService {
   async updateCategory(
     updateCategoryArgs: IUpdateCategoryArgs,
   ): Promise<CategoryResDto> {
-    const [category, categoryByName] = await Promise.all([
-      this.categoryRepo.findCategoryById({
-        userId: updateCategoryArgs.userId,
-        categoryId: updateCategoryArgs.categoryId,
-      }),
-      updateCategoryArgs.categoryName
-        ? this.categoryRepo.findCategoryByName({
-            userId: updateCategoryArgs.userId,
-            categoryName: updateCategoryArgs.categoryName,
-          })
-        : null,
-    ]);
+    const category = await this.categoryRepo.findCategoryById({
+      userId: updateCategoryArgs.userId,
+      categoryId: updateCategoryArgs.categoryId,
+    });
 
     if (!category) {
       throw new ConflictException('Category does not exist');
-    } else if (categoryByName) {
-      throw new ConflictException('Category already exists');
     }
 
     updateCategoryArgs.categoryName ??= category.name;

--- a/test/api/category/category.service.spec.ts
+++ b/test/api/category/category.service.spec.ts
@@ -397,6 +397,7 @@ describe('CategoryService', () => {
       const params = {
         userId,
         categoryId,
+        categoryName,
         color: newColor,
       };
       const repoRet = {
@@ -410,13 +411,19 @@ describe('CategoryService', () => {
         color: `#${newColor}`,
       };
 
+      const originalCategory = {
+        name: categoryName,
+        id: categoryId,
+        color,
+      };
+
       const categoryFindById = jest
         .spyOn(categoryRepo, 'findCategoryById')
-        .mockResolvedValue({
-          name: categoryName,
-          id: categoryId,
-          color,
-        });
+        .mockResolvedValue(originalCategory);
+
+      const categoryFindByName = jest
+        .spyOn(categoryRepo, 'findCategoryByName')
+        .mockResolvedValue(originalCategory);
 
       const categoryRepoSpy = jest
         .spyOn(categoryRepo, 'updateCategory')


### PR DESCRIPTION
* Closes #67 

## ✨ **구현 기능 명세**

기존에 카테고리 수정 api에, 색상만 변경할 경우 제대로 동작하지 않는 버그가 존재하였습니다. 이 버그를 해결하였습니다.

## 🎁 **주목할 점**

### 원인
```js
    const [category, categoryByName] = await Promise.all([
      this.categoryRepo.findCategoryById({
        userId: updateCategoryArgs.userId,
        categoryId: updateCategoryArgs.categoryId,
      }),
      updateCategoryArgs.categoryName
        ? this.categoryRepo.findCategoryByName({
            userId: updateCategoryArgs.userId,
            categoryName: updateCategoryArgs.categoryName,
          })
        : null,
    ]);

    if (!category) {
      throw new ConflictException('Category does not exist');
    } 
    // 이 else if 문이 원인
    else if (categoryByName) {
      throw new ConflictException('Category already exists');
    }
```

색상만 다르기 때문에 `categoryByName` 은 카테고리 객체였습니다. 색상만 변경을 원하는 경우 `categoryByName`은 null이 아니지만 exception이 발생하면 안됩니다. 따라서 위의 else if 문을 제거하여 해결했습니다.

## 🌄 **스크린샷**
![image](https://user-images.githubusercontent.com/32933980/235592644-aa12c376-ebd9-4f2f-a5aa-87d4fcfde76a.png)