### PR TITLE
범위 사이의 일정 정보를 가져올 때 모든 유저의 일정 정보를 가져오는 버그 수정

### DIFF
--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -29,18 +29,22 @@ export class PlanRepository extends Repository<PlanEntity> {
   async findPlansBetweenDate({
     timeMin,
     timeMax,
+    userId,
   }: IGetPlansArgs): Promise<PlanResDto[]> {
     return await this.find({
       where: [
         {
           startTime: Between(timeMin, timeMax),
+          userId,
         },
         {
           endTime: Between(timeMin, timeMax),
+          userId,
         },
         {
           startTime: LessThan(timeMin),
           endTime: MoreThan(timeMax),
+          userId,
         },
       ],
       select: PLAN_SELECT,


### PR DESCRIPTION
* Closes #69 

## ✨ **구현 기능 명세**

범위 사이의 일정 정보를 가져올 때 모든 유저가 아닌 해당하는 유저 일정만 가져오도록 변경했습니다.

## 🎁 **주목할 점**

### 원인

DB에서 가져오는 `where`문에 userId 값을 넣어주지 않아 필터링 되지 않았습니다.
서비스 로직에서 해당 데이터를 필터링하는 것은 더더욱 아닌 것 같아 `where` 문 안에 userId 값을 판단하도록 적용했습니다.

## 🌄 **스크린샷**

![image](https://github.com/JiPyoTak/plandar-server/assets/55688122/f73dc6ec-6b12-40fa-bfe5-39275fa85459)
