### PR TITLE
Plan Entity에서 category를 nullable 하도록 변경

### DIFF
--- a/src/entities/plan.entity.ts
+++ b/src/entities/plan.entity.ts
@@ -112,13 +112,13 @@ export class PlanEntity extends DefaultEntity {
   @ApiProperty({
     example: 1,
   })
-  @Column({ type: 'int' })
+  @Column({ type: 'int', nullable: true })
   @IsNumber()
-  categoryId!: number;
+  categoryId?: number;
 
   @ManyToOne(() => CategoryEntity, (category) => category.plans)
   @JoinColumn({ name: 'categoryId' })
-  category!: CategoryEntity;
+  category?: CategoryEntity;
 
   @ApiProperty({
     example: ['태그1', '태그2'],

--- a/src/entities/plan.entity.ts
+++ b/src/entities/plan.entity.ts
@@ -106,7 +106,7 @@ export class PlanEntity extends DefaultEntity {
   userId!: number;
 
   @ManyToOne(() => UserEntity, { onDelete: 'CASCADE', cascade: true })
-  @JoinColumn({ name: 'userId' })
+  @JoinColumn({ name: 'user_id' })
   user!: UserEntity;
 
   @ApiProperty({
@@ -117,7 +117,7 @@ export class PlanEntity extends DefaultEntity {
   categoryId?: number;
 
   @ManyToOne(() => CategoryEntity, (category) => category.plans)
-  @JoinColumn({ name: 'categoryId' })
+  @JoinColumn({ name: 'category_id' })
   category?: CategoryEntity;
 
   @ApiProperty({


### PR DESCRIPTION
* Closes #71 

## ✨ **구현 기능 명세**

Plan Entity에서 category를 nullable 하도록 변경하였습니다.

## 😭 **어려웠던 점**

어려웠던 점이라고 쓰고 멍청한 점이라고 읽습니다.

### synchronize: true

app.module.ts 에 `synchronize: true` 를 해주어야 테이블을 다시 생성하는데 이걸 해주지 않아서 왜 안되지 헤맸습니다.

### 제목은 required

제목은 필수인데 이것도 nullable인줄 알고 테스트하는데 안돼서 왜 안되지 헤맸습니다.

## 🔎 **추가 작업**

현재 Plan Entity 설정으로는 user_id, category_id column 외에 userId와 categoryId가 추가적으로 존재하였습니다.

```ts
@Entity('plan_tb')
export class PlanEntity extends DefaultEntity {
  // user
  @ApiProperty({
    example: 1,
  })
  @Column({ type: 'int' })
  @IsNumber()
  userId!: number;

  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE', cascade: true })
  // before: @JoinColumn({ name: 'userId' })
  @JoinColumn({ name: 'user_id' })
  user!: UserEntity;

  // category
  @ApiProperty({
    example: 1,
  })
  @Column({ type: 'int', nullable: true })
  @IsNumber()
  categoryId?: number;

  @ManyToOne(() => CategoryEntity, (category) => category.plans)
  // before: @JoinColumn({ name: 'categoryId' })
  @JoinColumn({ name: 'category_id' })
  category?: CategoryEntity;

}
```

JoinColumn의 name을 camelCase에서 snake_case로 변경하여 중복 칼럼이 생성되지 않도록 하였습니다.

## 🌄 **스크린샷**

### 테스트

![image](https://github.com/JiPyoTak/plandar-server/assets/32933980/0bd12ec6-ff13-4366-8aa0-495634e4f169)

### 생성된 record

![image](https://github.com/JiPyoTak/plandar-server/assets/32933980/e7cb25ea-b27b-4ec7-a100-9a112e254843)