### PR TITLE
태그 정보 string[]으로 오도록 변경

### DIFF
--- a/src/api/plan/plan.repository.ts
+++ b/src/api/plan/plan.repository.ts
@@ -9,7 +9,9 @@ import { PLAN_SELECT } from '@/utils/constants';
 
 @CustomRepository(PlanEntity)
 export class PlanRepository extends Repository<PlanEntity> {
-  async findPlanById(id: number): Promise<PlanResDto> {
+  async findPlanById(
+    id: number,
+  ): Promise<Omit<PlanResDto, 'tags'> & { tags?: TagResDto[] }> {
     return await this.findOne({
       where: { id },
       select: PLAN_SELECT,
@@ -30,7 +32,9 @@ export class PlanRepository extends Repository<PlanEntity> {
     timeMin,
     timeMax,
     userId,
-  }: IGetPlansArgs): Promise<PlanResDto[]> {
+  }: IGetPlansArgs): Promise<
+    (Omit<PlanResDto, 'tags'> & { tags?: TagResDto[] })[]
+  > {
     return await this.find({
       where: [
         {
@@ -54,7 +58,7 @@ export class PlanRepository extends Repository<PlanEntity> {
 
   async createPlan(
     planData: Omit<ICreatePlanArgs, 'tags'> & { tags: TagResDto[] },
-  ): Promise<PlanResDto> {
+  ): Promise<Omit<PlanResDto, 'tags'> & { tags?: TagResDto[] }> {
     const filteredPlan = this.create(planData);
 
     const { id } = await this.save(filteredPlan);
@@ -67,7 +71,7 @@ export class PlanRepository extends Repository<PlanEntity> {
     ...planData
   }: Omit<IUpdatePlanArgs, 'tags'> & {
     tags: TagResDto[];
-  }): Promise<PlanResDto> {
+  }): Promise<Omit<PlanResDto, 'tags'> & { tags?: TagResDto[] }> {
     const data = this.create({ ...planData, id });
     await this.save(data);
     return await this.findPlanById(id);

--- a/src/api/plan/plan.service.ts
+++ b/src/api/plan/plan.service.ts
@@ -17,6 +17,7 @@ import {
   IUpdatePlanWithTagsArgs,
 } from '@/types/args';
 import { mapToHexColor } from '@/utils/color-converter';
+import { mapTagsToStringArray } from '@/utils/tag-converter';
 
 import { PlanRepository } from './plan.repository';
 
@@ -48,7 +49,9 @@ export class PlanService {
   }
 
   async getPlans(data: IGetPlansArgs): Promise<PlanResDto[]> {
-    return mapToHexColor(await this.planRepo.findPlansBetweenDate(data));
+    return mapTagsToStringArray(
+      mapToHexColor(await this.planRepo.findPlansBetweenDate(data)),
+    );
   }
 
   @Transactional()
@@ -70,7 +73,7 @@ export class PlanService {
       tags: createdTags,
     });
 
-    return mapToHexColor(newPlan);
+    return mapTagsToStringArray(mapToHexColor(newPlan));
   }
 
   @Transactional()
@@ -95,7 +98,7 @@ export class PlanService {
       tags: createdTags,
     });
 
-    return mapToHexColor(updatedPlan);
+    return mapTagsToStringArray(mapToHexColor(updatedPlan));
   }
 
   @Transactional()
@@ -116,6 +119,6 @@ export class PlanService {
       ),
     );
 
-    return mapToHexColor({ ...plan, tags: tagDatas });
+    return mapTagsToStringArray(mapToHexColor({ ...plan, tags: tagDatas }));
   }
 }

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -25,7 +25,7 @@ class PlanResDto extends OmitType(PlanEntity, [
   })
   @IsArray()
   @ArrayMaxSize(5)
-  tags?: TagResDto[];
+  tags?: string[];
 }
 
 export { PlanResDto };

--- a/src/dto/plan/plan-res.dto.ts
+++ b/src/dto/plan/plan-res.dto.ts
@@ -1,7 +1,6 @@
-import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { ArrayMaxSize, IsArray, IsNumber } from 'class-validator';
 
-import { TagResDto } from '@/dto/tag';
 import { PlanEntity } from '@/entities';
 
 class PlanResDto extends OmitType(PlanEntity, [
@@ -19,13 +18,13 @@ class PlanResDto extends OmitType(PlanEntity, [
   @IsNumber()
   categoryId?: number;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     description: '일정이 가지고 있는 태그 객체',
     example: ['태그1', '태그2'],
   })
   @IsArray()
   @ArrayMaxSize(5)
-  tags?: string[];
+  tags!: string[];
 }
 
 export { PlanResDto };

--- a/src/utils/tag-converter.ts
+++ b/src/utils/tag-converter.ts
@@ -5,16 +5,15 @@ const tagToStringArray = (tags: TagResDto[]): string[] => {
 };
 
 const mapTagsToStringArray = <
-  IType extends { tags?: TagResDto[] },
+  IType extends { tags: TagResDto[] },
   TArgs = IType | IType[],
-  TForm = { tags?: TagResDto[] } & Omit<IType, 'tags'>,
+  TForm = { tags: TagResDto[] } & Omit<IType, 'tags'>,
   TReturn = TArgs extends any[] ? TForm[] : TForm,
 >(
   obj: TArgs,
 ): TReturn => {
   if (obj instanceof Array) {
     return obj.map(({ tags, ...rest }) => {
-      if (tags?.length === 0) return rest as TReturn;
       return {
         ...rest,
         tags: tagToStringArray(tags),
@@ -23,9 +22,7 @@ const mapTagsToStringArray = <
   }
 
   const { tags, ...rest } = obj as unknown as IType;
-  return (
-    tags?.length > 0 ? { ...rest, tags: tagToStringArray(tags) } : rest
-  ) as TReturn;
+  return { ...rest, tags: tagToStringArray(tags) } as TReturn;
 };
 
 export { mapTagsToStringArray };

--- a/src/utils/tag-converter.ts
+++ b/src/utils/tag-converter.ts
@@ -1,0 +1,31 @@
+import { TagResDto } from '@/dto/tag';
+
+const tagToStringArray = (tags: TagResDto[]): string[] => {
+  return tags.map(({ name }) => name);
+};
+
+const mapTagsToStringArray = <
+  IType extends { tags?: TagResDto[] },
+  TArgs = IType | IType[],
+  TForm = { tags?: TagResDto[] } & Omit<IType, 'tags'>,
+  TReturn = TArgs extends any[] ? TForm[] : TForm,
+>(
+  obj: TArgs,
+): TReturn => {
+  if (obj instanceof Array) {
+    return obj.map(({ tags, ...rest }) => {
+      if (tags?.length === 0) return rest as TReturn;
+      return {
+        ...rest,
+        tags: tagToStringArray(tags),
+      };
+    }) as TReturn;
+  }
+
+  const { tags, ...rest } = obj as unknown as IType;
+  return (
+    tags?.length > 0 ? { ...rest, tags: tagToStringArray(tags) } : rest
+  ) as TReturn;
+};
+
+export { mapTagsToStringArray };

--- a/test/api/plan/plan.controller.spec.ts
+++ b/test/api/plan/plan.controller.spec.ts
@@ -50,7 +50,10 @@ describe('PlanController', () => {
       const date = new Date();
       const [timeMin, timeMax] = getMonthRangeDate(date);
 
-      const plans = [{ ...PLAN_STUB }];
+      const plans = [{ ...PLAN_STUB }].map(({ tags, ...rest }) => ({
+        ...rest,
+        tags: tags.map(({ name }) => name),
+      }));
       const planServSpy = jest
         .spyOn(planService, 'getPlans')
         .mockResolvedValue(plans);
@@ -104,7 +107,10 @@ describe('PlanController', () => {
     it('expect success response - plans (Query with between time)', async () => {
       const timeMin = PLAN_TIME_MIN_STUB;
       const timeMax = PLAN_TIME_MAX_STUB;
-      const plans = [{ ...PLAN_STUB }];
+      const plans = [{ ...PLAN_STUB }].map(({ tags, ...rest }) => ({
+        ...rest,
+        tags: tags.map(({ name }) => name),
+      }));
       const planServSpy = jest
         .spyOn(planService, 'getPlans')
         .mockResolvedValue(plans);
@@ -194,7 +200,8 @@ describe('PlanController', () => {
         },
         ['id'],
       );
-      const planRes = { ...PLAN_STUB };
+      const { tags, ...rest } = PLAN_STUB;
+      const planRes = { ...rest, tags: tags.map(({ name }) => name) };
       const planServSpy = jest
         .spyOn(planService, 'createPlan')
         .mockResolvedValue(planRes);
@@ -255,7 +262,8 @@ describe('PlanController', () => {
         },
         ['id'],
       );
-      const planRes = { ...PLAN_STUB };
+      const { tags, ...rest } = PLAN_STUB;
+      const planRes = { ...rest, tags: tags.map(({ name }) => name) };
       const planServSpy = jest
         .spyOn(planService, 'updatePlan')
         .mockResolvedValue(planRes);
@@ -307,7 +315,8 @@ describe('PlanController', () => {
 
   describe('Delete /plan/:planId', () => {
     it('expect success response with deleting a plan', async () => {
-      const planRes = { ...PLAN_STUB };
+      const { tags, ...rest } = PLAN_STUB;
+      const planRes = { ...rest, tags: tags.map(({ name }) => name) };
       const planServSpy = jest
         .spyOn(planService, 'deletePlan')
         .mockResolvedValue(planRes);

--- a/test/api/plan/plan.service.spec.ts
+++ b/test/api/plan/plan.service.spec.ts
@@ -133,7 +133,10 @@ describe('PlanService', () => {
         timeMin: PLAN_TIME_MIN_STUB,
         timeMax: PLAN_TIME_MAX_STUB,
       };
-      const result = [{ ...PLAN_STUB_WITH_COLOR }];
+      const result = [{ ...PLAN_STUB_WITH_COLOR }].map(({ tags, ...rest }) => ({
+        ...rest,
+        tags: tags.map(({ name }) => name),
+      }));
       const planRepoSpy = jest
         .spyOn(planRepository, 'findPlansBetweenDate')
         .mockResolvedValue([{ ...PLAN_STUB }]);
@@ -194,7 +197,8 @@ describe('PlanService', () => {
         tags: PLAN_STUB.tags.map(({ name }) => name),
         userId: USER_STUB.id,
       };
-      const result = { ...PLAN_STUB_WITH_COLOR };
+      const { tags, ...rest } = PLAN_STUB_WITH_COLOR;
+      const result = { ...rest, tags: tags.map(({ name }) => name) };
       const categoryServSpy = jest
         .spyOn(categoryService, 'checkUserOwnCategory')
         .mockResolvedValue(undefined);
@@ -224,6 +228,7 @@ describe('PlanService', () => {
       expect(planRepoSpy).toHaveBeenCalledTimes(1);
       expect(planRepoSpy).toHaveBeenCalledWith({
         ...result,
+        tags,
         color: PLAN_STUB.color,
         userId: newPlanData.userId,
       });
@@ -279,7 +284,8 @@ describe('PlanService', () => {
         tags: PLAN_STUB.tags.map(({ name }) => name),
         userId: USER_STUB.id,
       };
-      const result = { ...PLAN_STUB_WITH_COLOR };
+      const { tags, ...rest } = PLAN_STUB_WITH_COLOR;
+      const result = { ...rest, tags: tags.map(({ name }) => name) };
       const planCheckUserOwnPlanSpy = jest
         .spyOn(planService, 'checkUserOwnPlan')
         .mockResolvedValue(undefined);
@@ -313,6 +319,7 @@ describe('PlanService', () => {
       expect(planRepoSpy).toHaveBeenCalledTimes(1);
       expect(planRepoSpy).toHaveBeenCalledWith({
         ...result,
+        tags,
         color: PLAN_STUB.color,
         userId: planData.userId,
       });
@@ -326,7 +333,8 @@ describe('PlanService', () => {
         planId: PLAN_STUB.id,
         userId: USER_STUB.id,
       };
-      const result = { ...PLAN_STUB_WITH_COLOR };
+      const { tags, ...rest } = PLAN_STUB_WITH_COLOR;
+      const result = { ...rest, tags: tags.map(({ name }) => name) };
       const planCheckUserOwnPlanSpy = jest
         .spyOn(planService, 'checkUserOwnPlan')
         .mockResolvedValue(undefined);

--- a/test/api/plan/stub.ts
+++ b/test/api/plan/stub.ts
@@ -5,29 +5,31 @@ import { PLAN_TYPE } from '@/entities';
 const PLAN_TIME_MIN_STUB = new Date('2023-03-07T00:00:00.000000Z');
 const PLAN_TIME_MAX_STUB = new Date('2023-03-07T23:59:59.999999Z');
 
-const PLAN_STUB: PlanResDto = Object.freeze({
-  id: 1,
-  title: 'MyPlan',
-  description: '',
-  color: '123456',
-  startTime: new Date(
-    '2023-03-07T15:38:06.785155Z',
-  ).toUTCString() as unknown as Date,
-  endTime: null,
-  type: PLAN_TYPE.TASK,
-  isAllDay: true,
+const PLAN_STUB: Omit<PlanResDto, 'tags'> & { tags: TagResDto[] } =
+  Object.freeze({
+    id: 1,
+    title: 'MyPlan',
+    description: '',
+    color: '123456',
+    startTime: new Date(
+      '2023-03-07T15:38:06.785155Z',
+    ).toUTCString() as unknown as Date,
+    endTime: null,
+    type: PLAN_TYPE.TASK,
+    isAllDay: true,
 
-  categoryId: 1,
-  tags: [
-    { id: 1, name: '태그1' },
-    { id: 2, name: '태그2' },
-  ] as TagResDto[],
-});
+    categoryId: 1,
+    tags: [
+      { id: 1, name: '태그1' },
+      { id: 2, name: '태그2' },
+    ] as TagResDto[],
+  });
 
-const PLAN_STUB_WITH_COLOR: PlanResDto = Object.freeze({
-  ...PLAN_STUB,
-  color: '#123456',
-});
+const PLAN_STUB_WITH_COLOR: Omit<PlanResDto, 'tags'> & { tags: TagResDto[] } =
+  Object.freeze({
+    ...PLAN_STUB,
+    color: '#123456',
+  });
 
 export {
   PLAN_STUB,


### PR DESCRIPTION
* Closes #73 

## ✨ **구현 기능 명세**

Plan의 태그관련 정보가 { id: number; name: string; }[] 형태로 넘어오던 것을 string[] 형태로 넘겨받도록 수정하였습니다.

## 🎁 **주목할 점**

### mapTagsToStringArray

기존에 작성되어있던 `mapToHexColor` 유틸함수를 tags에 적용하였습니다.

```ts
// 정의
const mapTagsToStringArray = <
  IType extends { tags: TagResDto[] },
  TArgs = IType | IType[],
  TForm = { tags: TagResDto[] } & Omit<IType, 'tags'>,
  TReturn = TArgs extends any[] ? TForm[] : TForm,
>(
  obj: TArgs,
): TReturn => {
  if (obj instanceof Array) {
    return obj.map(({ tags, ...rest }) => {
      return {
        ...rest,
        tags: tagToStringArray(tags),
      };
    }) as TReturn;
  }

  const { tags, ...rest } = obj as unknown as IType;
  return { ...rest, tags: tagToStringArray(tags) } as TReturn;
};


// 사용시
    return mapTagsToStringArray(mapToHexColor(newPlan));
```

만약 위에서 `newPlan`이 배열이라면 `mapToHexColor` 에서 O(N), `mapTagsToStringArray` 에서 다시 한 번 O(N) 이 소요됩니다. 결국 O(2N) 이 되어서 `mapToHexColor`와 `mapTagsToStringArray`를 합치는 것도 생각해보았습니다만, category api 쪽에서도 `mapHexColor` 를 사용하고 있으며 이 경우에는 `mapTagsToStringArray`를 사용하지 않아도 됩니다. 그래서 그냥 합치지 않고 따로 만들었습니다. 

## 🌄 **스크린샷**

![image](https://github.com/JiPyoTak/plandar-server/assets/32933980/6182b9de-1a16-4b3b-a890-fc4feb4741c6)
